### PR TITLE
fix(driver): per-thread SCHED_FIFO on the render thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "human-panic",
+ "libc",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.5.16", features = ["derive"] }
 embedded-graphics.workspace = true
 hostname = "0.4"
 human-panic = "2.0"
+libc = "0.2"
 opentelemetry = { version = "0.30", features = ["metrics", "logs"] }
 opentelemetry-appender-tracing = "0.30"
 opentelemetry-otlp = { version = "0.30", default-features = false, features = [

--- a/crates/driver/src/display.rs
+++ b/crates/driver/src/display.rs
@@ -59,7 +59,14 @@ pub struct Panel {
     pub mode_config: JsonValue,
 }
 
-pub async fn drive(
+/// Synchronous render loop. Designed to run on a dedicated OS thread
+/// (see `main.rs`) so the matrix bit-bang doesn't share scheduling
+/// budget with the tokio runtime workers. The body never `.await`s —
+/// state is read through a `parking_lot::RwLock` and the bonnet sink
+/// blocks on GPIO — so an `async fn` would just be ceremony that
+/// pulls this loop back into the runtime we explicitly want it out
+/// of.
+pub fn drive(
     mut sink: Box<dyn MatrixSink>,
     state: Arc<RwLock<State>>,
     metrics: Arc<Metrics>,

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -9,6 +9,7 @@ pub const DRIVER_VERSION: &str = env!("LED_DRIVER_VERSION");
 pub mod config;
 pub mod display;
 pub mod realtime;
+pub mod sched;
 pub mod sink;
 pub mod state;
 pub mod telemetry;

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -4,6 +4,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use anyhow::Context;
 use clap::Parser;
 use parking_lot::RwLock;
 use tokio::task::JoinSet;
@@ -11,6 +12,7 @@ use tokio::task::JoinSet;
 use led_driver::{
     config,
     display::drive,
+    sched,
     sink::{MatrixSink, TerminalMatrixSink},
     state::{self, State},
     telemetry,
@@ -86,8 +88,49 @@ async fn main() -> anyhow::Result<()> {
     let state = Arc::new(RwLock::new(State::default()));
 
     tracing::info!("Spawning tasks...");
-    let mut tasks = JoinSet::new();
-    tasks.spawn(drive(sink, state.clone(), metrics.clone()));
+    let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
+
+    // Render loop runs on a dedicated OS thread, NOT a tokio worker.
+    // This is a single-thread-FIFO design: the renderer alone bumps
+    // itself to SCHED_FIFO/locked memory; tokio workers + OTel +
+    // reqwest all stay SCHED_OTHER so PID 1 systemd keeps getting
+    // scheduled and the BCM2835 hardware watchdog keeps getting pet.
+    let render_state = state.clone();
+    let render_metrics = metrics.clone();
+    let render_thread = std::thread::Builder::new()
+        .name("led-render".into())
+        .spawn(move || -> anyhow::Result<()> {
+            // Promote SELF (this thread) to FIFO. Soft-fail: dev box,
+            // qemu, or a missing LimitRTPRIO/CAP_SYS_NICE cause EPERM
+            // here — better to render a flickery panel than to refuse
+            // to start.
+            if let Err(err) = sched::promote_current_thread_to_fifo(50) {
+                tracing::warn!(
+                    %err,
+                    "render thread: SCHED_FIFO promotion failed; flicker may regress. \
+                     Check LimitRTPRIO=50 in led-driver.service or that the binary has CAP_SYS_NICE."
+                );
+            }
+            if let Err(err) = sched::lock_all_memory() {
+                tracing::warn!(
+                    %err,
+                    "render thread: mlockall failed; page faults may cause flicker. \
+                     Check LimitMEMLOCK=infinity in led-driver.service."
+                );
+            }
+            drive(sink, render_state, render_metrics)
+        })
+        .context("spawn led-render thread")?;
+
+    // Bridge the std::thread into the JoinSet via the blocking pool so
+    // a renderer error/panic still surfaces in `join_next` and tears
+    // the process down (Restart=always brings us back).
+    tasks.spawn_blocking(move || {
+        render_thread
+            .join()
+            .map_err(|panic| anyhow::anyhow!("led-render thread panicked: {panic:?}"))?
+    });
+
     tasks.spawn(async move {
         state::sync(
             config.id,

--- a/crates/driver/src/sched.rs
+++ b/crates/driver/src/sched.rs
@@ -1,0 +1,78 @@
+//! Per-thread realtime scheduling primitives.
+//!
+//! HUB75 panels need a tight bit-bang loop with microsecond-level
+//! jitter tolerance. The natural fit is `SCHED_FIFO`, but applying it
+//! to the whole driver process — e.g. via systemd's
+//! `CPUSchedulingPolicy=fifo` — also promotes the tokio runtime
+//! workers, `OTel` batch exporter, reqwest pool, and tracing-appender
+//! threads. Tokio workers in particular spin on their task queues and
+//! don't yield cleanly under FIFO; on a single-core Pi Zero W they
+//! starve PID 1 systemd long enough to miss the BCM2835 hardware
+//! watchdog (1-min timeout) and the kernel reboots before
+//! multi-user.target. See `project_pi_realtime_scheduling.md`.
+//!
+//! The fix is per-thread: only the matrix render thread sets
+//! `SCHED_FIFO` on itself; everyone else stays ``SCHED_OTHER``. The
+//! render thread also `mlockall`s its memory so a page fault during
+//! a DMA-driven row update can't introduce a stall.
+//!
+//! All functions soft-fail with a returned error rather than
+//! panicking — dev boxes / qemu / containers without `CAP_SYS_NICE`
+//! or `RLIMIT_RTPRIO` should still run, just at `SCHED_OTHER` (and
+//! probably with visible flicker).
+
+use std::io;
+
+/// Promote the calling thread to `SCHED_FIFO` at the given priority.
+///
+/// `priority` must be in 1..=99 per `sched(7)`. We default to 50
+/// elsewhere in the driver — high enough to preempt `SCHED_OTHER`
+/// reliably, low enough that any genuinely critical kernel RT thread
+/// (PRIO 99) still wins.
+///
+/// Requires `CAP_SYS_NICE` (or being root) AND `RLIMIT_RTPRIO >=
+/// priority`. The systemd unit sets `LimitRTPRIO=` accordingly; on
+/// Linux returns `EPERM` otherwise. Non-Linux targets are a no-op
+/// (this matters for the terminal sink in `just dev` on macOS).
+#[cfg(target_os = "linux")]
+pub fn promote_current_thread_to_fifo(priority: i32) -> io::Result<()> {
+    let param = libc::sched_param {
+        sched_priority: priority,
+    };
+    // tid = 0 means "calling thread" in `sched_setscheduler(2)`.
+    let rc = unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &raw const param) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn promote_current_thread_to_fifo(_priority: i32) -> io::Result<()> {
+    Ok(())
+}
+
+/// Lock the process's current and future memory so the render thread
+/// never page-faults mid-frame. Affects the whole process (mlock
+/// isn't per-thread), but the only memory we'd otherwise risk paging
+/// is the rendering hot path and its scratch buffers — which is
+/// exactly what we want resident.
+///
+/// Requires `RLIMIT_MEMLOCK >= memory-resident-set-size`. The
+/// systemd unit sets `LimitMEMLOCK=infinity`; on Linux returns
+/// `ENOMEM` otherwise. Non-Linux targets are a no-op.
+#[cfg(target_os = "linux")]
+pub fn lock_all_memory() -> io::Result<()> {
+    let rc = unsafe { libc::mlockall(libc::MCL_CURRENT | libc::MCL_FUTURE) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn lock_all_memory() -> io::Result<()> {
+    Ok(())
+}

--- a/service/led-driver.service
+++ b/service/led-driver.service
@@ -15,17 +15,23 @@ Restart=always
 RestartSec=2s
 User=root
 
-# rpi-led-panel drives HUB75 via tight CPU + DMA loops, so preemption
-# mid-frame shows up as visible flicker. We *want* SCHED_FIFO here,
-# but on the Zero W's single core, FIFO=99 with no budget cap starved
-# PID 1 systemd to the point that it couldn't pet the BCM2835 hardware
-# watchdog (1-min timeout) and the kernel rebooted before multi-user
-# was ever reached — see the led-delta forensics on 2026-04-28 (20
-# boots in 100 minutes, none reached multi-user.target). Until we wire
-# up CPUQuota + LimitRTPRIO + a tuned kernel.sched_rt_runtime_us, we
-# stick with nice/io preference only. Visible flicker may regress on
-# the Pi Zero W; the fix path is to add bounded RT later, not to
-# reinstate unbounded FIFO.
+# Realtime scheduling is set per-thread inside the driver — only the
+# `led-render` OS thread bumps itself to SCHED_FIFO+50, while the
+# tokio runtime workers, OTel exporter, reqwest pool, and
+# tracing-appender stay SCHED_OTHER. This is the shape that works on
+# the Zero W's single core: a process-wide CPUSchedulingPolicy=fifo
+# (incl. the "bounded" form with CPUQuota+sched_rt_runtime_us) starves
+# PID 1 systemd long enough to miss the BCM2835 hardware watchdog
+# (1-min timeout) and the kernel reboots before multi-user.target —
+# see led-delta forensics 2026-04-28 and led-alpha 2026-04-29.
+#
+# We just need to give the driver permission to do the per-thread
+# bump itself: RTPRIO so it can call sched_setscheduler(SCHED_FIFO,
+# 50), and MEMLOCK so the render thread can mlockall() to keep its
+# hot path resident. Without these the calls EPERM/ENOMEM and the
+# driver logs a warning and continues at SCHED_OTHER.
+LimitRTPRIO=50
+LimitMEMLOCK=infinity
 Nice=-20
 IOSchedulingClass=realtime
 IOSchedulingPriority=0


### PR DESCRIPTION
## Summary

- Pull the matrix render loop out of the tokio runtime onto a dedicated OS thread (`led-render`); only that thread bumps itself to `SCHED_FIFO 50` + `mlockall()`. Tokio workers + OTel exporter + reqwest pool + tracing-appender stay `SCHED_OTHER`.
- This is the shape needed on the Pi Zero W's single core. The previous "process-wide FIFO via systemd" approach (and even the bounded form with `CPUQuota=85%` + `sched_rt_runtime_us=80%`) starves PID 1 long enough to miss the BCM2835 hardware watchdog. Confirmed on led-delta 2026-04-28 and again on led-alpha 2026-04-29 (this branch was born of that incident).
- New `crates/driver/src/sched.rs` wraps `sched_setscheduler` + `mlockall` with Linux-only `cfg`s (no-ops elsewhere — keeps `just dev` happy on macOS).
- Unit file: add `LimitRTPRIO=50` and `LimitMEMLOCK=infinity` so the syscalls don't EPERM/ENOMEM. Drop the obsolete `CPUSchedulingPolicy=fifo` comment block.
- **Soft-fail** if the syscalls fail (dev box, qemu, missing CAP_SYS_NICE). Driver logs a warning and renders at `SCHED_OTHER` rather than refusing to start.

## Why the simpler approaches fail

| Approach | Problem |
|---|---|
| `CPUSchedulingPolicy=fifo` (process-wide) | Promotes all 8 threads incl. tokio workers; PID 1 starves → watchdog reboot |
| `Nice=-20 + IOSchedulingClass=realtime` | Just hints; doesn't guarantee preemption-free render → flicker |
| `CPUSchedulingPolicy=fifo` + `CPUQuota=85%` | CPUQuota uses CFS controller; doesn't apply to SCHED_FIFO threads |
| Above + `kernel.sched_rt_runtime_us=800000` | Guarantees opportunity for SCHED_OTHER but not a slice for PID 1 specifically; PID 1 still loses races vs tailscaled/kernel-softirqs |
| **Per-thread SCHED_FIFO** (this PR) | Only render thread is RT; everyone else schedules normally |

This is also the pattern hzeller's `rpi-rgb-led-matrix` C++ uses (`pthread_setschedparam` on its render thread).

## Test plan

- [x] `cargo check -p led-driver` (default + `--no-default-features`)
- [x] `cargo clippy` clean on touched files
- [x] Local smoke run with `--terminal --config /tmp/...`: render thread spawns, terminal sink animates, `sched_setscheduler` + `mlockall` log expected `EPERM` / `ENOMEM` warnings (running unprivileged), driver doesn't crash.
- [ ] Cross-compile with `just build` (Docker required; reviewer / CI to verify)
- [ ] Flash one panel (e.g. led-alpha after recovery), verify:
   - `chrt -p $(pgrep -x led-driver)` shows `SCHED_OTHER` for PID
   - `for tid in /proc/$pid/task/*; do ...` shows the `led-render` TID at `SCHED_FIFO 50`, all others `SCHED_OTHER`
   - System reaches `multi-user.target`, no watchdog reboots over a 30-min soak
   - HUB75 flicker is visibly reduced vs current `Nice=-20` baseline
- [ ] If soak passes, re-flash bravo / charlie / delta

## Recovery context

led-alpha is currently in a watchdog-reboot loop from the failed in-place test of the bounded-RT systemd approach. SD card pull + `rm /etc/systemd/system/led-driver.service.d/realtime.conf` is the recovery; this branch's flashed image will replace whatever's on the card anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)