### PR TITLE
Frontend deep-clean: data layer, perf, a11y, composer-kit refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -934,7 +934,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "led-driver"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "led-wifi-setup"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/display-core", "crates/driver", "crates/wifi-setup"]
 # = true` picks it up. Internal-fleet system; we ship as a unit, so
 # per-crate semver doesn't carry information for us.
 [workspace.package]
-version = "1.1.3"
+version = "1.1.4"
 # wasm-sim has its own [profile.release] (opt-level = "z", lto, single
 # codegen unit — wasm-pack defaults) that would conflict with the
 # workspace's release profile, so keep it out and build it via

--- a/dash/bun.lock
+++ b/dash/bun.lock
@@ -25,6 +25,8 @@
         "zod": "^4",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -39,6 +41,8 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -221,6 +225,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@react-aria/focus": ["@react-aria/focus@3.22.0", "", { "dependencies": { "@swc/helpers": "^0.5.0", "react-aria": "3.48.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg=="],
 
@@ -410,7 +416,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "axe-core": ["axe-core@4.11.3", "", {}, "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg=="],
+    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -617,6 +623,8 @@
     "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -916,6 +924,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
@@ -1173,6 +1185,8 @@
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-jsx-a11y/axe-core": ["axe-core@4.11.3", "", {}, "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "led-dash",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "packageManager": "bun@1.2.20",
   "scripts": {
@@ -31,6 +31,8 @@
     "zod": "^4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/dash/src/app/components/ColorPicker.tsx
+++ b/dash/src/app/components/ColorPicker.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Switch } from "@headlessui/react";
+import { useState } from "react";
 
+import { Fader } from "@/app/components/Fader";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
 
 export type ColorState =
@@ -15,6 +17,16 @@ export type ColorState =
       speed: number;
     };
 
+type RgbState = Extract<ColorState, { mode: "rgb" }>;
+type RainbowState = Extract<ColorState, { mode: "rainbow" }>;
+
+const DEFAULT_RGB: RgbState = { mode: "rgb", rgb: { r: 255, g: 138, b: 44 } };
+const DEFAULT_RAINBOW: RainbowState = {
+  mode: "rainbow",
+  perLetter: false,
+  speed: 16,
+};
+
 export function ColorPicker({
   value,
   onChange,
@@ -22,6 +34,26 @@ export function ColorPicker({
   value: ColorState;
   onChange: (c: ColorState) => void;
 }) {
+  // Remember the last-seen sub-state for each mode so toggling
+  // rgb→rainbow→rgb restores the user's color (and the rainbow
+  // speed/per-letter) instead of hard-resetting to LED-orange. The
+  // stashes are updated through `commit` (an event-handler path), and
+  // the incoming `value` seeds whichever mode is currently active.
+  const [lastRgb, setLastRgb] = useState<RgbState>(
+    value.mode === "rgb" ? value : DEFAULT_RGB,
+  );
+  const [lastRainbow, setLastRainbow] = useState<RainbowState>(
+    value.mode === "rainbow" ? value : DEFAULT_RAINBOW,
+  );
+
+  // Forward an edit to the parent and stash it as the last-known
+  // sub-state for its mode.
+  const commit = (next: ColorState) => {
+    if (next.mode === "rgb") setLastRgb(next);
+    else setLastRainbow(next);
+    onChange(next);
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -34,13 +66,7 @@ export function ColorPicker({
           </span>
           <Switch
             checked={value.mode === "rainbow"}
-            onChange={(on) => {
-              if (on) {
-                onChange({ mode: "rainbow", perLetter: false, speed: 16 });
-              } else {
-                onChange({ mode: "rgb", rgb: { r: 255, g: 138, b: 44 } });
-              }
-            }}
+            onChange={(on) => onChange(on ? lastRainbow : lastRgb)}
             className={[
               "relative inline-flex h-4 w-7 items-center rounded-sm border transition",
               value.mode === "rainbow"
@@ -69,7 +95,7 @@ export function ColorPicker({
       {value.mode === "rgb" ? (
         <SolidColorPicker
           value={value.rgb}
-          onChange={(rgb) => onChange({ mode: "rgb", rgb })}
+          onChange={(rgb) => commit({ mode: "rgb", rgb })}
         />
       ) : (
         <div className="space-y-3">
@@ -78,44 +104,28 @@ export function ColorPicker({
             className="h-3 w-full"
             style={{
               background:
-                "linear-gradient(90deg, #ff4d6d, #ff8a2c, #ffe066, #a6e22e, #4de0e0, #4da3ff, #a04dff, #ff4d6d)",
+                "linear-gradient(90deg, var(--color-swatch-rose), var(--color-swatch-amber), var(--color-swatch-sun), var(--color-swatch-lime), var(--color-swatch-cyan), var(--color-swatch-azure), var(--color-swatch-violet), var(--color-swatch-rose))",
             }}
           />
-          <div className="flex items-center gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              slow
-            </span>
-            <input
-              type="range"
-              min={1}
-              max={50}
-              value={value.speed}
-              onChange={(e) =>
-                onChange({ ...value, speed: Number(e.target.value) })
-              }
-              className="fader flex-1"
-              style={
-                {
-                  ["--fader-pos" as string]: `${(value.speed / 50) * 100}%`,
-                } as React.CSSProperties
-              }
-              aria-label="Rainbow speed"
-            />
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              fast
-            </span>
-            <span className="w-8 text-right font-mono text-[10px] tabular-nums text-(--color-text)">
-              {String(value.speed).padStart(2, "0")}
-            </span>
-          </div>
+          <Fader
+            label="// speed"
+            value={value.speed}
+            min={1}
+            max={50}
+            step={1}
+            onChange={(speed) => commit({ ...value, speed })}
+            format={(v) => String(v).padStart(2, "0")}
+            endpoints={["slow", "fast"]}
+            ariaLabel="Rainbow speed"
+          />
           <label className="flex cursor-pointer items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-muted)">
             <input
               type="checkbox"
               checked={value.perLetter}
               onChange={(e) =>
-                onChange({ ...value, perLetter: e.target.checked })
+                commit({ ...value, perLetter: e.target.checked })
               }
-              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus:ring-0 focus:ring-offset-0"
+              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
             />
             per-letter phase
           </label>

--- a/dash/src/app/components/Composer.tsx
+++ b/dash/src/app/components/Composer.tsx
@@ -17,6 +17,7 @@ export function Composer({
   onEffectsChange,
   onSubmit,
   disabled,
+  transmitFailed = false,
 }: {
   message: string;
   onMessageChange: (s: string) => void;
@@ -26,6 +27,9 @@ export function Composer({
   onEffectsChange: (e: EffectsState) => void;
   onSubmit: () => Promise<void> | void;
   disabled: boolean;
+  /** True when the last transmit threw. Surfaced as a status + banner;
+   * cleared by the parent when the payload is edited. */
+  transmitFailed?: boolean;
 }) {
   const [submitting, setSubmitting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -36,7 +40,13 @@ export function Composer({
     setSubmitting(true);
     try {
       await onSubmit();
+      // Refocus only on confirmed success — onSubmit re-throws on
+      // failure, so a throw skips this line. An unconditional refocus
+      // would re-summon the mobile keyboard even when transmit failed.
       inputRef.current?.focus();
+    } catch {
+      // Failure state is owned by the parent (transmitFailed); swallow
+      // here so the rejection doesn't surface as an unhandled error.
     } finally {
       setSubmitting(false);
     }
@@ -44,9 +54,11 @@ export function Composer({
 
   const status = submitting
     ? "transmitting"
-    : disabled
-      ? "awaiting payload"
-      : "ready / press ↵";
+    : transmitFailed
+      ? "transmit failed"
+      : disabled
+        ? "awaiting payload"
+        : "ready / press ↵";
 
   const countTone =
     message.length === 0
@@ -161,6 +173,15 @@ export function Composer({
         />
 
         <div className="border-t border-dashed border-(--color-hairline)" />
+
+        {transmitFailed ? (
+          <p
+            role="alert"
+            className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)"
+          >
+            transmit failed · payload kept · retry
+          </p>
+        ) : null}
 
         <button
           type="submit"

--- a/dash/src/app/components/EffectsPanel.tsx
+++ b/dash/src/app/components/EffectsPanel.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-const FORCE_MARQUEE_THRESHOLD = 12;
+/** Single source of truth: at/above this length the marquee is
+ * auto-enabled (a static message this long won't fit the panel).
+ * page.tsx imports this so the force-enable threshold can't drift. */
+export const FORCE_ENABLE_MARQUEE_LENGTH = 12;
 const MAX_SPEED = 50;
 
 export type EffectsState = {
@@ -16,7 +19,7 @@ export function EffectsPanel({
   onChange: (e: EffectsState) => void;
   messageLength: number;
 }) {
-  const isForced = messageLength >= FORCE_MARQUEE_THRESHOLD;
+  const isForced = messageLength >= FORCE_ENABLE_MARQUEE_LENGTH;
   const min = isForced ? 1 : 0;
   // Defensive: never render below `min`.
   const displayValue = isForced ? Math.max(value.marqueeSpeed, min) : value.marqueeSpeed;
@@ -61,5 +64,3 @@ export function EffectsPanel({
     </div>
   );
 }
-
-export const FORCE_ENABLE_MARQUEE_LENGTH = FORCE_MARQUEE_THRESHOLD;

--- a/dash/src/app/components/EntriesList.tsx
+++ b/dash/src/app/components/EntriesList.tsx
@@ -14,11 +14,21 @@ export function EntriesList() {
   const entriesData = entries.get.useSWR(panelId);
   const scrollData = entries.scroll.get.useSWR(panelId);
 
-  // While a drag/reorder/delete is in flight we render the optimistic
-  // list; once the round-trip completes we drop back to server-driven
-  // by setting it null. Avoids the setState-in-effect anti-pattern.
-  const [optimistic, setOptimistic] = useState<TextEntryItem[] | null>(null);
-  const items = optimistic ?? entriesData.data?.entries ?? [];
+  // Local order is held ONLY while a drag is in progress (framer-motion
+  // needs a stable `values` array to animate against mid-drag). On drag
+  // end we commit once; otherwise we render straight from the SWR cache,
+  // whose optimistic update is owned by actions.ts.
+  const [dragOrder, setDragOrder] = useState<TextEntryItem[] | null>(null);
+  // Inline error surfaced when a reorder/delete round-trip fails. The
+  // optimistic cache rolls back in actions.ts; this tells the user why
+  // the list snapped back.
+  const [actionError, setActionError] = useState<string | null>(null);
+  // Row pending delete confirmation — a first click arms it, a second
+  // (or the explicit confirm button) commits. Guards against fat-finger
+  // deletes from the tiny per-row control.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const serverItems = entriesData.data?.entries ?? [];
+  const items = dragOrder ?? serverItems;
 
   if (entriesData.isLoading) {
     return <Empty muted>loading messages ···</Empty>;
@@ -48,27 +58,44 @@ export function EntriesList() {
   const scroll = scrollData.data?.scroll ?? 0;
   const visibleCount = Math.min(VISIBLE_SLOTS, items.length - scroll);
 
-  const handleReorder = async (next: TextEntryItem[]) => {
-    setOptimistic(next);
+  // During a drag framer-motion fires onReorder on every intermediate
+  // position. We only stash the new order locally here — committing on
+  // each move spammed N parallel UPDATEs per pixel of travel.
+  const handleReorder = (next: TextEntryItem[]) => {
+    setDragOrder(next);
+  };
+
+  // Commit the final order exactly once when the drag settles. Compare
+  // against the server order so a click (no actual move) is a no-op.
+  const handleReorderCommit = async () => {
+    const next = dragOrder;
+    if (!next) return;
+    const serverIds = serverItems.map((e) => e.id).join(",");
+    const nextIds = next.map((e) => e.id);
+    if (nextIds.join(",") === serverIds) {
+      setDragOrder(null);
+      return;
+    }
+    setActionError(null);
     try {
-      await entries.reorder.call(
-        panelId,
-        next.map((e) => e.id),
-      );
-      await entriesData.mutate({ entries: next });
+      await entries.reorder.call(panelId, nextIds);
+    } catch {
+      // actions.ts already rolled back the optimistic cache; tell the
+      // user why the list jumped back.
+      setActionError("reorder failed · order restored");
     } finally {
-      setOptimistic(null);
+      // Drop back to the (now-authoritative or rolled-back) SWR cache.
+      setDragOrder(null);
     }
   };
 
-  const handleDelete = async (id: string) => {
-    const next = items.filter((e) => e.id !== id);
-    setOptimistic(next);
+  const handleDelete = async (entry: TextEntryItem) => {
+    setConfirmingId(null);
+    setActionError(null);
     try {
-      await entries.delete.call(panelId, id);
-      await entriesData.mutate({ entries: next });
-    } finally {
-      setOptimistic(null);
+      await entries.delete.call(panelId, entry.id);
+    } catch {
+      setActionError(`delete failed · "${entry.data.text}" restored`);
     }
   };
 
@@ -93,6 +120,16 @@ export function EntriesList() {
           </span>
         </span>
       </div>
+
+      {actionError ? (
+        <p
+          role="alert"
+          className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)"
+        >
+          {actionError}
+        </p>
+      ) : null}
+
       <Reorder.Group
         axis="y"
         values={items}
@@ -106,6 +143,9 @@ export function EntriesList() {
               <Reorder.Item
                 key={entry.id}
                 value={entry}
+                // Commit the final order once the drag settles, not on
+                // every intermediate onReorder move.
+                onDragEnd={() => void handleReorderCommit()}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
@@ -178,18 +218,47 @@ export function EntriesList() {
                   </span>
                 )}
 
-                <motion.button
-                  type="button"
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={() => handleDelete(entry.id)}
-                  // Touch devices don't fire :hover, so the
-                  // group-hover gate would render the button
-                  // unreachable; show it always there.
-                  className="shrink-0 cursor-pointer p-1 text-(--color-text-faint) transition-colors hover:text-(--color-danger) sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
-                  aria-label="Delete"
-                >
-                  <TrashIcon className="h-3 w-3" />
-                </motion.button>
+                {confirmingId === entry.id ? (
+                  // Two-step confirm: avoids an irreversible delete from
+                  // a single mis-tap on the small per-row control.
+                  <span className="flex shrink-0 items-center gap-1">
+                    <motion.button
+                      type="button"
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={() => void handleDelete(entry)}
+                      className="flex min-h-8 cursor-pointer items-center border border-(--color-danger)/50 bg-(--color-danger)/10 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger) transition-colors hover:bg-(--color-danger)/20"
+                      aria-label={`Confirm delete message "${entry.data.text}"`}
+                    >
+                      delete
+                    </motion.button>
+                    <motion.button
+                      type="button"
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={() => setConfirmingId(null)}
+                      className="flex min-h-8 cursor-pointer items-center px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint) transition-colors hover:text-(--color-text)"
+                      aria-label="Cancel delete"
+                    >
+                      cancel
+                    </motion.button>
+                  </span>
+                ) : (
+                  <motion.button
+                    type="button"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() => {
+                      setActionError(null);
+                      setConfirmingId(entry.id);
+                    }}
+                    // Touch devices don't fire :hover, so the
+                    // group-hover gate would render the button
+                    // unreachable; show it always there. 32px min hit
+                    // target for touch (the icon stays small).
+                    className="flex min-h-8 min-w-8 shrink-0 cursor-pointer items-center justify-center text-(--color-text-faint) transition-colors hover:text-(--color-danger) sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                    aria-label={`Delete message "${entry.data.text}"`}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </motion.button>
+                )}
               </Reorder.Item>
             );
           })}

--- a/dash/src/app/components/Fader.tsx
+++ b/dash/src/app/components/Fader.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Shared labeled slider. Replaces the hand-rolled `pct` slider +
+ * preset-chip rows duplicated across shapes / gif / life. The native
+ * `<input type=range>` carries the keyboard model (arrows step, the
+ * thumb takes focus) so this is keyboard-operable for free; the
+ * `.fader` class (globals.css) draws the LED-orange filled track.
+ *
+ * `presets` renders snap chips below the slider. `format` controls the
+ * right-aligned value readout; `endpoints` labels the slider extremes
+ * (e.g. slow/fast, wire/solid).
+ */
+export function Fader({
+  label,
+  value,
+  min,
+  max,
+  step = 0.01,
+  onChange,
+  format = (v) => v.toFixed(2),
+  endpoints,
+  presets,
+  presetLabel = (v) => `${v}`,
+  ariaLabel,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (next: number) => void;
+  /** Right-aligned readout of the current value. */
+  format?: (v: number) => string;
+  /** Labels for the slider extremes, e.g. ["slow", "fast"]. */
+  endpoints?: [string, string];
+  /** Snap-to values rendered as chips below the slider. */
+  presets?: number[];
+  /** Chip text for a preset value. */
+  presetLabel?: (v: number) => string;
+  ariaLabel?: string;
+}) {
+  const pct = max > min ? ((value - min) / (max - min)) * 100 : 0;
+
+  return (
+    <div className="space-y-2.5">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
+          {label}
+        </span>
+        <span
+          className="tabular-nums text-(--color-text)"
+          style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
+        >
+          {format(value)}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {endpoints ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
+            {endpoints[0]}
+          </span>
+        ) : null}
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="fader flex-1"
+          style={{ ["--fader-pos" as string]: `${pct}%` } as React.CSSProperties}
+          aria-label={ariaLabel ?? label}
+        />
+        {endpoints ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
+            {endpoints[1]}
+          </span>
+        ) : null}
+      </div>
+
+      {presets && presets.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1">
+          {presets.map((p) => {
+            const active = Math.abs(value - p) < 0.01;
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => onChange(p)}
+                className={[
+                  "border px-2 py-1 font-mono text-[9px] uppercase tracking-[0.25em] transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
+                  active
+                    ? "border-(--color-accent) bg-(--color-accent)/15 text-(--color-accent)"
+                    : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",
+                ].join(" ")}
+              >
+                {presetLabel(p)}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dash/src/app/components/InstrumentHeader.tsx
+++ b/dash/src/app/components/InstrumentHeader.tsx
@@ -70,7 +70,7 @@ export function InstrumentHeader({
           <Telemetry
             label="off"
             value={pad(stats.off)}
-            tone={stats.off > 0 ? "dim" : "dim"}
+            tone={stats.off > 0 ? "warn" : "dim"}
           />
         </div>
 

--- a/dash/src/app/components/LiveDot.tsx
+++ b/dash/src/app/components/LiveDot.tsx
@@ -4,22 +4,31 @@ import type { RealtimeStatus } from "@/utils/actions";
 
 const PRESETS: Record<
   RealtimeStatus,
-  { color: string; glow: string; label: string }
+  { color: string; glow: string; label: string; glyph: string; sr: string }
 > = {
   live: {
     color: "var(--color-phosphor)",
     glow: "var(--color-phosphor)",
     label: "live",
+    // Filled circle: a steady, present signal.
+    glyph: "●",
+    sr: "realtime channel live",
   },
   connecting: {
     color: "var(--color-amber)",
     glow: "var(--color-amber)",
     label: "boot",
+    // Ellipsis: mid-handshake / connecting.
+    glyph: "…",
+    sr: "realtime channel connecting",
   },
   down: {
     color: "var(--color-danger)",
     glow: "var(--color-danger)",
     label: "down",
+    // Multiplication sign: channel dropped.
+    glyph: "✕",
+    sr: "realtime channel down",
   },
 };
 
@@ -28,11 +37,17 @@ const PRESETS: Record<
  * subscription state (connecting → live, or down on error/timeout).
  * Phosphor-green dot when subscribed; amber while joining; warm red
  * if the channel dropped.
+ *
+ * State is conveyed three ways so it survives color-blindness and the
+ * lamp being decorative: a per-state glyph, the always-present text
+ * label, and an explicit accessible name on the wrapper.
  */
 export function LiveDot({ status }: { status: RealtimeStatus }) {
   const preset = PRESETS[status];
   return (
     <span
+      role="status"
+      aria-label={preset.sr}
       className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.25em]"
       style={{ color: preset.color }}
     >
@@ -54,7 +69,12 @@ export function LiveDot({ status }: { status: RealtimeStatus }) {
           }}
         />
       </span>
-      <span>{preset.label}</span>
+      {/* Non-color cue: a glyph that differs per state, so the three
+       * states are distinguishable without relying on hue. */}
+      <span aria-hidden className="leading-none">
+        {preset.glyph}
+      </span>
+      <span aria-hidden>{preset.label}</span>
     </span>
   );
 }

--- a/dash/src/app/components/MatrixPreview.tsx
+++ b/dash/src/app/components/MatrixPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
@@ -34,6 +35,118 @@ type Scene = {
 
 const DEFAULT_COLOR: WireColor = { Rgb: { r: 255, g: 138, b: 44 } };
 const FLASH_OFF = { is_active: false, on_steps: 0, total_steps: 0 };
+
+// Geometry derived from container width + DPR. Recomputed cheaply on
+// resize/DPR change without tearing down the render loop.
+type Geometry = {
+  cell: number;
+  cornerRadius: number;
+  w: number;
+  h: number;
+  dpr: number;
+};
+
+function computeGeometry(containerWidth: number, dpr: number): Geometry {
+  const padding = 24;
+  const target = Math.max(120, containerWidth - padding);
+  const fit = Math.max(2, Math.floor((target - GAP) / COLS) - GAP);
+  const cell = Math.min(CELL_CAP, fit);
+  const w = COLS * (cell + GAP) + GAP;
+  const h = ROWS * (cell + GAP) + GAP;
+  const cornerRadius = Math.max(0.5, cell * 0.18);
+  return { cell, cornerRadius, w, h, dpr };
+}
+
+// Cache of precomputed glow sprites. Each lit LED previously created a
+// fresh radial gradient every frame (up to ~245k gradients/sec at 60fps
+// on a full panel). Instead we bake one glow sprite per quantized
+// (r,g,b,intensityBucket) into an offscreen canvas and drawImage it.
+// The visual is identical: the gradient stops and falloff match the
+// old per-pixel math, only quantized into buckets fine enough to be
+// imperceptible yet coarse enough to bound the cache to a few hundred
+// entries in practice.
+const COLOR_QUANT = 16; // 4-bit per channel
+const INTENSITY_BUCKETS = 16;
+
+class GlowCache {
+  private sprites = new Map<number, HTMLCanvasElement>();
+  // `cell` determines sprite geometry, so the cache is invalidated
+  // whenever the resolved cell size changes (rare — only on resize).
+  private cell = -1;
+  private dpr = 1;
+
+  reset(cell: number, dpr: number) {
+    if (cell === this.cell && dpr === this.dpr) return;
+    this.cell = cell;
+    this.dpr = dpr;
+    this.sprites.clear();
+  }
+
+  // Returns a glow sprite for the given color/intensity. `halfExtent`
+  // (in CSS px) is the distance from sprite center to edge; callers
+  // draw it centered on the LED so the glow blooms past the package.
+  get(
+    r: number,
+    g: number,
+    b: number,
+    intensity: number,
+  ): { sprite: HTMLCanvasElement; halfExtent: number } | null {
+    const qr = Math.min(15, r >> 4);
+    const qg = Math.min(15, g >> 4);
+    const qb = Math.min(15, b >> 4);
+    const qi = Math.min(
+      INTENSITY_BUCKETS - 1,
+      Math.floor(intensity * INTENSITY_BUCKETS),
+    );
+    // Pack into a single int key: 4 bits each rgb + 4 bits intensity.
+    const key = (qr << 12) | (qg << 8) | (qb << 4) | qi;
+
+    let sprite = this.sprites.get(key);
+    if (!sprite) {
+      const built = this.build(qr, qg, qb, qi);
+      if (!built) return null;
+      sprite = built;
+      this.sprites.set(key, sprite);
+    }
+    // halfExtent is encoded as the CSS half-size of the sprite.
+    const half = sprite.width / this.dpr / 2;
+    return { sprite, halfExtent: half };
+  }
+
+  private build(
+    qr: number,
+    qg: number,
+    qb: number,
+    qi: number,
+  ): HTMLCanvasElement | null {
+    const cell = this.cell;
+    const dpr = this.dpr;
+    // Reconstruct representative channel/intensity from bucket centers.
+    const r = Math.min(255, qr * COLOR_QUANT + COLOR_QUANT / 2);
+    const g = Math.min(255, qg * COLOR_QUANT + COLOR_QUANT / 2);
+    const b = Math.min(255, qb * COLOR_QUANT + COLOR_QUANT / 2);
+    const intensity = (qi + 0.5) / INTENSITY_BUCKETS;
+
+    // Same falloff math as the original per-pixel gradient.
+    const haloRadius = cell * 0.4 + cell * 2.2 * Math.pow(intensity, 1.4);
+    const alpha = 0.35 * Math.pow(intensity, 1.2);
+
+    const size = Math.max(1, Math.ceil(haloRadius * 2));
+    const off = document.createElement("canvas");
+    off.width = Math.max(1, Math.round(size * dpr));
+    off.height = off.width;
+    const octx = off.getContext("2d");
+    if (!octx) return null;
+    octx.scale(dpr, dpr);
+    const c = haloRadius;
+    const grad = octx.createRadialGradient(c, c, 0, c, c, haloRadius);
+    grad.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
+    grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+    octx.fillStyle = grad;
+    octx.fillRect(0, 0, size, size);
+    return off;
+  }
+}
 
 /**
  * Bit-exact LED-matrix simulator. Loads the driver's render core
@@ -69,6 +182,12 @@ export function MatrixPreview({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [containerWidth, setContainerWidth] = useState(640);
   const rendererRef = useRef<WasmRenderer | null>(null);
+  // Flips true once the async WASM import resolves. The scene-push
+  // effect depends on it so the current scene gets pushed the moment
+  // the renderer exists — otherwise a scene built before the import
+  // resolved would never reach the renderer and tick() would render
+  // an empty default forever.
+  const [rendererReady, setRendererReady] = useState(false);
 
   useLayoutEffect(() => {
     const wrap = wrapperRef.current;
@@ -80,18 +199,27 @@ export function MatrixPreview({
     return () => ro.disconnect();
   }, []);
 
-  // Load the WASM module once on mount.
+  // Load the WASM module once on mount. The import is async, so the
+  // Renderer can be constructed after a fast unmount has already run
+  // cleanup — guard against leaking it by freeing immediately if the
+  // effect was cancelled before construction resolved.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       const mod = await import("wasm-sim");
-      if (cancelled) return;
-      rendererRef.current = new mod.Renderer(COLS, ROWS);
+      const renderer = new mod.Renderer(COLS, ROWS);
+      if (cancelled) {
+        renderer.free();
+        return;
+      }
+      rendererRef.current = renderer;
+      setRendererReady(true);
     })();
     return () => {
       cancelled = true;
       rendererRef.current?.free();
       rendererRef.current = null;
+      setRendererReady(false);
     };
   }, []);
 
@@ -131,52 +259,136 @@ export function MatrixPreview({
     };
   }, [items, mode, scroll, isPaused, isOff]);
 
-  // Push state into the renderer whenever it actually changes.
-  // The frame ref can rebuild for reasons that don't affect the
-  // serialized payload (SWR refresh handing back a fresh
-  // mode_config object reference, life ticks bumping a sub-tree
-  // we don't actually care about, etc.), and JSON.stringify of a
-  // fully-loaded gif scene is ~720KB on the main thread. Hash via
-  // stringify exactly once per change and dedupe.
-  const lastJsonRef = useRef<string | null>(null);
-  useEffect(() => {
-    const json = JSON.stringify(frame);
-    if (json === lastJsonRef.current) return;
-    lastJsonRef.current = json;
-    rendererRef.current?.setSceneJson(json);
-  }, [frame]);
+  // Whether the active mode produces motion. Static modes (image,
+  // test) and an empty/blank text panel never advance, so once their
+  // frame is painted there's nothing to animate. Clock advances but
+  // only at 1Hz — we still treat it as animated so the rAF loop runs
+  // (a 1Hz redraw is negligible and the WASM tick is what advances it),
+  // but it's gated off when offline/paused/off like everything else.
+  const isAnimatedMode =
+    "Text" in mode
+      ? frame.mode &&
+        "Text" in frame.mode &&
+        frame.mode.Text.entries.some((e) => e.text.trim().length > 0)
+      : "Clock" in mode ||
+        "Life" in mode ||
+        "Gif" in mode ||
+        "Shapes" in mode;
 
-  // rAF loop: tick the WASM renderer and paint to canvas. Cell size
-  // adapts to container width; the matrix is 64×64 logical pixels
-  // upscaled to discrete LEDs with a 1px gap and slight corner radius.
+  // The loop only needs to run when something can actually change on
+  // screen. When the panel is offline/paused/off or the scene is
+  // static, we render a single frame and idle until state changes.
+  const shouldAnimate = !offline && !isPaused && !isOff && isAnimatedMode;
+
+  // Push state into the renderer whenever it actually changes. The
+  // frame ref can rebuild for reasons that don't affect the rendered
+  // output (SWR refresh handing back a fresh object reference, etc.).
+  // The old code full-`JSON.stringify`'d the scene on every rebuild to
+  // dedupe — but a loaded gif scene is ~720KB and clock rebuilds at
+  // 1Hz, so that stringified large payloads on the main thread for no
+  // reason. Instead we dedupe with a cheap structural key plus a
+  // reference check on the bitmap payload, and only stringify once we
+  // know the scene genuinely changed.
+  const lastKeyRef = useRef<string | null>(null);
+  // Reference to the bitmap payload array (image.bitmap / gif.frames)
+  // we last serialized. Those arrays are rebuilt on real content change,
+  // so a reference match means the 720KB payload is unchanged and we can
+  // skip stringifying it entirely.
+  const lastBitmapRef = useRef<unknown>(null);
+  // Bumped only when the scene the renderer holds actually changed, so
+  // an idle (static-mode) loop knows to repaint exactly once.
+  const [sceneVersion, setSceneVersion] = useState(0);
   useEffect(() => {
+    const renderer = rendererRef.current;
+    // Don't record the dedupe key until we actually have a renderer to
+    // push to — otherwise we'd mark the scene "pushed" against a null
+    // renderer and never retry once it loads. `rendererReady` in the
+    // deps re-runs this the moment the import resolves.
+    if (!renderer) return;
+    const key = structuralKey(frame);
+    const m = frame.mode;
+    // Bitmap modes carry huge arrays the structural key can't cheaply
+    // summarize; track the array reference so reference-stable SWR churn
+    // skips the stringify. Non-bitmap modes leave this null.
+    const bitmap = "Image" in m ? m.Image.bitmap : "Gif" in m ? m.Gif.frames : null;
+
+    // Fast path: structural key unchanged AND (for bitmap modes) the
+    // payload array is reference-identical → nothing the renderer cares
+    // about changed.
+    if (
+      key === lastKeyRef.current &&
+      (bitmap === null || bitmap === lastBitmapRef.current)
+    ) {
+      return;
+    }
+
+    // Only stringify when something actually changed — for a 720KB gif
+    // this now happens on real updates, not on every SWR refresh.
+    const json = JSON.stringify(frame);
+    lastKeyRef.current = key;
+    lastBitmapRef.current = bitmap;
+    renderer.setSceneJson(json);
+    // Wake an idled loop so it repaints this new scene exactly once.
+    setSceneVersion((v) => v + 1);
+  }, [frame, rendererReady]);
+
+  // Geometry lives in a ref so resize/DPR changes recompute it cheaply
+  // without rebuilding the render loop. The loop reads geometryRef each
+  // frame; a separate effect resizes the backing canvas + invalidates
+  // the glow cache when geometry changes.
+  const geometryRef = useRef<Geometry>(computeGeometry(640, 1));
+  const glowCacheRef = useRef(new GlowCache());
+  // Lazy-init from the real DPR on the client (SSR falls back to 1).
+  // The canvas backing store is sized via effect, not server-rendered,
+  // so reading DPR here can't cause a hydration mismatch.
+  const [dpr, setDpr] = useState(() =>
+    typeof window === "undefined" ? 1 : window.devicePixelRatio || 1,
+  );
+
+  // Re-read DPR whenever it changes (moving the window between a Retina
+  // and an external display). matchMedia on the current dpr fires once
+  // when the ratio leaves the matched value; we re-subscribe each time.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(`(resolution: ${dpr}dppx)`);
+    const onChange = () => setDpr(window.devicePixelRatio || 1);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [dpr]);
+
+  // Resize the backing store + recompute geometry on width/DPR change.
+  // Separate from the render loop so a resize doesn't tear it down.
+  const [geometryVersion, setGeometryVersion] = useState(0);
+  useLayoutEffect(() => {
     const c = canvasRef.current;
     if (!c) return;
-    const ctx = c.getContext("2d");
-    if (!ctx) return;
+    const geom = computeGeometry(containerWidth, dpr);
+    geometryRef.current = geom;
+    c.width = geom.w * geom.dpr;
+    c.height = geom.h * geom.dpr;
+    c.style.width = `${geom.w}px`;
+    c.style.height = `${geom.h}px`;
+    glowCacheRef.current.reset(geom.cell, geom.dpr);
+    // Resizing the canvas clears it, so force at least one repaint even
+    // when the loop is idle.
+    setGeometryVersion((v) => v + 1);
+  }, [containerWidth, dpr]);
 
-    const padding = 24;
-    const target = Math.max(120, containerWidth - padding);
-    const fit = Math.max(2, Math.floor((target - GAP) / COLS) - GAP);
-    const cell = Math.min(CELL_CAP, fit);
-    const w = COLS * (cell + GAP) + GAP;
-    const h = ROWS * (cell + GAP) + GAP;
-    const dpr = window.devicePixelRatio || 1;
-    c.width = w * dpr;
-    c.height = h * dpr;
-    c.style.width = `${w}px`;
-    c.style.height = `${h}px`;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  // The single-frame painter. Pulls current pixels from the renderer
+  // (unless offline), then runs the three-pass LED draw. Returns false
+  // when the renderer isn't ready yet so the caller can keep polling.
+  const paint = useCallback(
+    (ctx: CanvasRenderingContext2D): boolean => {
+      const { cell, cornerRadius, w, h, dpr: gdpr } = geometryRef.current;
+      // setTransform is cheap; re-apply each paint so a context-restore
+      // (which resets transform) is always corrected.
+      ctx.setTransform(gdpr, 0, 0, gdpr, 0, 0);
 
-    const cornerRadius = Math.max(0.5, cell * 0.18);
-    const unlitFill = "rgba(255,255,255,0.05)";
-
-    let raf = 0;
-    const draw = () => {
       const renderer = rendererRef.current;
       let pixels: Uint8Array | null = null;
-      // Don't tick the renderer when the panel is offline — there's
-      // no real state to mirror, and advancing `step` against a stale
+      let ready = renderer != null;
+      // Don't tick the renderer when the panel is offline — there's no
+      // real state to mirror, and advancing `step` against a stale
       // frame would just animate ghosts.
       if (!offline) {
         try {
@@ -184,6 +396,7 @@ export function MatrixPreview({
         } catch {
           // Renderer not yet initialized or transient error — fall
           // through to drawing the unlit grid.
+          ready = false;
         }
       }
 
@@ -191,7 +404,7 @@ export function MatrixPreview({
 
       // Pass 1: unlit substrate. Cheap, no glow.
       ctx.shadowBlur = 0;
-      ctx.fillStyle = unlitFill;
+      ctx.fillStyle = "rgba(255,255,255,0.05)";
       for (let row = 0; row < ROWS; row++) {
         for (let col = 0; col < COLS; col++) {
           if (pixels) {
@@ -206,14 +419,14 @@ export function MatrixPreview({
         }
       }
 
-      if (!pixels) {
-        raf = requestAnimationFrame(draw);
-        return;
-      }
+      if (!pixels) return ready;
 
       // Pass 2: lit LEDs as a soft outer halo. Real LEDs at full
-      // brightness bloom well past their package — gamma-curved so
-      // dim LEDs barely glow and bright ones spill into neighbors.
+      // brightness bloom well past their package — gamma-curved so dim
+      // LEDs barely glow and bright ones spill into neighbors. We
+      // drawImage a precomputed glow sprite instead of building a fresh
+      // radial gradient per LED per frame.
+      const cache = glowCacheRef.current;
       ctx.globalCompositeOperation = "lighter";
       for (let row = 0; row < ROWS; row++) {
         for (let col = 0; col < COLS; col++) {
@@ -224,15 +437,17 @@ export function MatrixPreview({
           if (!r && !g && !b) continue;
 
           const intensity = Math.max(r, g, b) / 255;
-          const haloRadius = cell * 0.4 + cell * 2.2 * Math.pow(intensity, 1.4);
+          const glow = cache.get(r, g, b, intensity);
+          if (!glow) continue;
           const cx = GAP + col * (cell + GAP) + cell / 2;
           const cy = GAP + row * (cell + GAP) + cell / 2;
-          const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, haloRadius);
-          const alpha = 0.35 * Math.pow(intensity, 1.2);
-          grad.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
-          grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
-          ctx.fillStyle = grad;
-          ctx.fillRect(cx - haloRadius, cy - haloRadius, haloRadius * 2, haloRadius * 2);
+          ctx.drawImage(
+            glow.sprite,
+            cx - glow.halfExtent,
+            cy - glow.halfExtent,
+            glow.halfExtent * 2,
+            glow.halfExtent * 2,
+          );
         }
       }
 
@@ -259,19 +474,111 @@ export function MatrixPreview({
           if (intensity > 0.5) {
             const corePad = cell * 0.3;
             ctx.fillStyle = `rgba(255,255,255,${(intensity - 0.5) * 0.5})`;
-            ctx.fillRect(x + corePad, y + corePad, cell - corePad * 2, cell - corePad * 2);
+            ctx.fillRect(
+              x + corePad,
+              y + corePad,
+              cell - corePad * 2,
+              cell - corePad * 2,
+            );
           }
         }
       }
+      return ready;
+    },
+    [offline],
+  );
 
-      raf = requestAnimationFrame(draw);
+  // Lets an idle loop be woken for a single repaint (scene/geometry
+  // change) without rebuilding the whole loop. No-op while animating —
+  // the continuous loop already repaints every frame.
+  const requestIdlePaintRef = useRef<() => void>(() => {});
+
+  // Render loop lifecycle. Re-runs ONLY when the loop *kind* changes
+  // (animated vs. idle) or when `paint` changes — NOT on geometry or
+  // scene ticks, which the loop reads from refs. A plain resize or a
+  // static-mode scene update repaints once (via requestIdlePaintRef)
+  // instead of tearing down and rebuilding the loop. Context loss is
+  // handled inline with re-init.
+  useEffect(() => {
+    const c = canvasRef.current;
+    if (!c) return;
+
+    let ctx = c.getContext("2d", { desynchronized: true });
+    if (!ctx) return;
+
+    let raf = 0;
+    let lost = false;
+
+    const animatedDraw = () => {
+      if (lost) return;
+      paint(ctx!);
+      raf = requestAnimationFrame(animatedDraw);
     };
-    raf = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(raf);
-  }, [containerWidth, offline]);
+
+    // Idle modes paint a single frame. If the WASM renderer isn't ready
+    // yet (still importing), keep polling until it is, then settle —
+    // an external wake (requestIdlePaintRef) handles real changes, so
+    // there's no steady-state rAF cost.
+    const idleDraw = () => {
+      if (lost) return;
+      const ready = paint(ctx!);
+      if (!ready) raf = requestAnimationFrame(idleDraw);
+    };
+
+    const start = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(shouldAnimate ? animatedDraw : idleDraw);
+    };
+
+    requestIdlePaintRef.current = () => {
+      if (lost || shouldAnimate) return;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(idleDraw);
+    };
+
+    const onLost = (e: Event) => {
+      e.preventDefault();
+      lost = true;
+      cancelAnimationFrame(raf);
+    };
+    const onRestored = () => {
+      lost = false;
+      const restored = c.getContext("2d", { desynchronized: true });
+      if (!restored) return;
+      ctx = restored;
+      // Backing-store dimensions survive a restore but content is
+      // cleared; restart the loop to repaint cleanly.
+      start();
+    };
+
+    c.addEventListener("contextlost", onLost as EventListener);
+    c.addEventListener("contextrestored", onRestored as EventListener);
+    start();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      requestIdlePaintRef.current = () => {};
+      c.removeEventListener("contextlost", onLost as EventListener);
+      c.removeEventListener("contextrestored", onRestored as EventListener);
+    };
+  }, [paint, shouldAnimate]);
+
+  // Wake an idle loop for a one-shot repaint when the scene or geometry
+  // actually changed. While animating this is a no-op.
+  useEffect(() => {
+    requestIdlePaintRef.current();
+  }, [sceneVersion, geometryVersion]);
 
   const matrixIdle =
     "Text" in mode && mode.Text.entries.length === 0 && items.length === 0;
+
+  const describe = () => {
+    if (offline) return "LED matrix simulator — panel offline, no heartbeat.";
+    const modeName = (Object.keys(mode)[0] ?? "unknown").toLowerCase();
+    const state = isOff ? "off" : isPaused ? "paused" : "live";
+    if (matrixIdle) return `LED matrix simulator — ${modeName} mode, idle.`;
+    return `LED matrix simulator — ${modeName} mode, ${state}.`;
+  };
 
   return (
     <div
@@ -284,7 +591,8 @@ export function MatrixPreview({
       />
       <canvas
         ref={canvasRef}
-        aria-label="LED matrix simulator"
+        role="img"
+        aria-label={describe()}
         className="relative mx-auto block"
       />
       {offline ? (
@@ -303,6 +611,55 @@ export function MatrixPreview({
       ) : null}
     </div>
   );
+}
+
+// Cheap structural fingerprint of the parts of the scene that change
+// the render *without* serializing large bitmap payloads. Bitmap modes
+// (image/gif) only summarize their dimensions/frame-count here; their
+// deep changes are caught by a payload-array reference check in the
+// push effect. Everything else is fully captured by this key.
+function structuralKey(frame: Scene): string {
+  const { panel, mode } = frame;
+  const p = `${panel.is_paused ? 1 : 0}${panel.is_off ? 1 : 0}`;
+  if ("Text" in mode) {
+    const t = mode.Text;
+    const entries = t.entries
+      .map((e) => {
+        const color = "Rgb" in e.options.color
+          ? `r${e.options.color.Rgb.r},${e.options.color.Rgb.g},${e.options.color.Rgb.b}`
+          : `w${e.options.color.Rainbow.is_per_letter}:${e.options.color.Rainbow.speed}`;
+        return `${e.text}|${color}|${e.options.marquee.speed}`;
+      })
+      .join("§");
+    return `${p}|T|${t.scroll}|${entries}`;
+  }
+  if ("Clock" in mode) {
+    const cl = mode.Clock;
+    return `${p}|C|${cl.format}|${cl.show_seconds}|${cl.show_meridiem}|${cl.color.r},${cl.color.g},${cl.color.b}|${cl.now.hour}:${cl.now.minute}:${cl.now.second}`;
+  }
+  if ("Life" in mode) {
+    const l = mode.Life;
+    return `${p}|L|${l.lattice_width}x${l.lattice_height}|${l.color.r},${l.color.g},${l.color.b}|n${l.cells.length}`;
+  }
+  if ("Shapes" in mode) {
+    const s = mode.Shapes;
+    return `${p}|S|${s.kind}|${s.color.r},${s.color.g},${s.color.b}|${s.speed}|${s.depth_shade}|${s.opacity}`;
+  }
+  if ("Image" in mode) {
+    const i = mode.Image;
+    return `${p}|I|${i.width}x${i.height}|n${i.bitmap.length}`;
+  }
+  if ("Gif" in mode) {
+    const g = mode.Gif;
+    return `${p}|G|${g.width}x${g.height}|${g.speed}|f${g.frames.length}`;
+  }
+  if ("Test" in mode) return `${p}|X|${mode.Test.pattern}`;
+  if ("Boot" in mode) {
+    const c = mode.Boot.color;
+    return `${p}|B|${c.r},${c.g},${c.b}`;
+  }
+  const su = mode.Setup;
+  return `${p}|U|${su.ssid}|${su.portal_url}`;
 }
 
 // Minimal type for what we actually use from the wasm module — keeps

--- a/dash/src/app/components/PanelSwitcher.tsx
+++ b/dash/src/app/components/PanelSwitcher.tsx
@@ -1,20 +1,29 @@
 "use client";
 
 import { PowerIcon } from "@heroicons/react/24/outline";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import { panels } from "@/utils/actions";
 import { isOffline, relativeTime } from "@/utils/offline";
 import { useNow } from "@/utils/useNow";
 
-type VersionState = "current" | "stale" | "dirty" | "unreported";
+/**
+ * The id of the content region these tabs drive — the matrix
+ * simulator section in page.tsx. Each tab's `aria-controls` points
+ * here so AT announces the tab/panel relationship. page.tsx must
+ * carry the matching `id={PANEL_CONTENT_ID}` + `role="tabpanel"`.
+ */
+export const PANEL_CONTENT_ID = "panel-content";
+
+type VersionState = "current" | "stale" | "dirty" | "legacy" | "unreported";
 
 type SemverTriple = [number, number, number];
 
 /** Parse a leading `MAJOR.MINOR.PATCH` triple, ignoring any trailing
  * label. Returns `null` for legacy git-SHA versions that don't match
  * the shape — those aren't comparable, so we skip them in the max
- * search and treat them as `current` at classify time. */
+ * search and flag them as `legacy` (not `current`) at classify time
+ * so a stale old build can't masquerade as up-to-date. */
 function parseSemver(v: string): SemverTriple | null {
   const cleaned = v.replace(/-dirty$/, "");
   const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(cleaned);
@@ -45,12 +54,42 @@ function classifyVersions(versions: (string | null)[]): VersionState[] {
     if (v == null) return "unreported";
     if (v.endsWith("-dirty")) return "dirty";
     const parsed = parseSemver(v);
-    // Legacy git-SHA versions can't be ordered against semvers, so
-    // we don't claim they're stale — show them as-is and let the
-    // user reflash if they care.
-    if (!parsed || !max) return "current";
+    // Legacy git-SHA (or otherwise non-semver) versions can't be
+    // ordered against semvers. Don't silently call them `current` —
+    // a stale old build would masquerade as up-to-date. Surface them
+    // as `legacy` so the user knows the version is unverified.
+    if (!parsed) return "legacy";
+    // No parseable fleet-max to compare against → can't prove stale.
+    if (!max) return "current";
     return cmpSemver(parsed, max) < 0 ? "stale" : "current";
   });
+}
+
+/** Short human label for a panel's operational state, used for both
+ * the visible chip and the consolidated accessible name. Mirrors the
+ * lamp priority: offline (truth check) → off → paused → live. */
+function stateLabel(p: {
+  is_off: boolean;
+  is_paused: boolean;
+}): "offline" | "off" | "paused" | "live" {
+  return p.is_off ? "off" : p.is_paused ? "paused" : "live";
+}
+
+/** Trailing version clause for the accessible name. Keeps state out
+ * of color alone — every distinction is also spelled in text. */
+function versionClause(version: string | null, state: VersionState): string {
+  switch (state) {
+    case "unreported":
+      return "version not reported";
+    case "legacy":
+      return version ? `legacy build ${version}` : "legacy build";
+    case "dirty":
+      return version ? `dirty build ${version}` : "dirty build";
+    case "stale":
+      return version ? `stale, driver ${version}` : "stale";
+    case "current":
+      return version ? `driver ${version}` : "driver up to date";
+  }
 }
 
 export function PanelSwitcher({
@@ -67,9 +106,44 @@ export function PanelSwitcher({
     [list],
   );
 
+  // Refs to each tab button, so arrow-key navigation can move DOM
+  // focus to the newly-selected tab (roving tabindex pattern).
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
   // Cheap re-render every 5s so the offline badge rolls over
   // without a fresh data pull.
   const now = useNow(5_000);
+
+  // ARIA tab pattern: arrow keys move selection (and focus) between
+  // tabs; Home/End jump to the ends. Selection follows focus, which
+  // matches a single-content-region switcher.
+  const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        next = (index + 1) % list.length;
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        next = (index - 1 + list.length) % list.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = list.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const target = list[next];
+    if (target) {
+      onChange(target.id);
+      tabRefs.current[next]?.focus();
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2 font-mono text-[11px]">
@@ -103,6 +177,9 @@ export function PanelSwitcher({
           const versionState = versionStates[i];
           const offline = isOffline(p.last_seen, now);
           const heartbeatLabel = `last seen ${relativeTime(p.last_seen, now)}`;
+          // `offline` is a derived liveness truth-check that overrides
+          // the panel's reported on/off/paused state in the label.
+          const state = offline ? "offline" : stateLabel(p);
           const tooltip = [
             p.description || p.name,
             heartbeatLabel,
@@ -111,6 +188,13 @@ export function PanelSwitcher({
           ]
             .filter(Boolean)
             .join(" · ");
+
+          // One clean accessible name per tab: "<name> — <state>,
+          // <version clause>". State is always spelled out (never
+          // color-only); offline drops the version clause as moot.
+          const accessibleName = offline
+            ? `${p.name} — offline, ${heartbeatLabel}`
+            : `${p.name} — ${state}, ${versionClause(p.driver_version, versionState)}`;
 
           // Status indicator: phosphor lamp for live-active, dim for
           // off, amber for paused, danger for offline, dim for
@@ -129,8 +213,17 @@ export function PanelSwitcher({
           return (
             <button
               key={p.id}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
               role="tab"
+              type="button"
+              id={`panel-tab-${p.id}`}
               aria-selected={active}
+              aria-controls={PANEL_CONTENT_ID}
+              aria-label={accessibleName}
+              tabIndex={active ? 0 : -1}
+              onKeyDown={(e) => onKeyDown(e, i)}
               onClick={() => onChange(p.id)}
               className={[
                 "group relative flex flex-col gap-0.5 border-l-2 px-2 py-1.5 text-left transition-colors",
@@ -184,25 +277,28 @@ export function PanelSwitcher({
                   {p.name}
                 </span>
 
-                {/* Right-side state chips */}
+                {/* Right-side state chips. Decorative — the tab's
+                 * `aria-label` carries the canonical state, so these
+                 * are hidden from AT to avoid a muddy double-read. */}
                 {p.is_off ? (
                   <PowerIcon
-                    aria-label="off"
-                    title={`off · ${heartbeatLabel}`}
+                    aria-hidden
                     className="h-3 w-3 shrink-0 text-(--color-text-faint)"
                   />
                 ) : null}
                 {p.is_paused ? (
                   <span
-                    aria-label="paused"
-                    title={`paused · ${heartbeatLabel}`}
+                    aria-hidden
                     className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-amber)/80"
                   >
                     ❚❚
                   </span>
                 ) : null}
                 {offline ? (
-                  <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger)/80">
+                  <span
+                    aria-hidden
+                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger)/80"
+                  >
                     offline
                   </span>
                 ) : null}
@@ -240,12 +336,14 @@ function VersionTag({
     current: "text-(--color-text-faint)",
     stale: "text-(--color-danger)/80",
     dirty: "text-(--color-amber)/80",
+    legacy: "text-(--color-amber)/80",
     unreported: "text-(--color-text-faint)/60",
   };
   const label: Record<VersionState, string> = {
     current: "v",
     stale: "stale",
     dirty: "dirty",
+    legacy: "legacy",
     unreported: "—",
   };
 

--- a/dash/src/app/components/SegmentedToggle.tsx
+++ b/dash/src/app/components/SegmentedToggle.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useId, useRef } from "react";
+
+export type SegmentOption<T extends string> = {
+  id: T;
+  label: string;
+  /** Optional tooltip / longer description. */
+  blurb?: string;
+};
+
+/**
+ * Shared "pick one of N" control — a `role="radiogroup"` of pill
+ * segments with the dark-instrument aesthetic. Replaces the divergent
+ * hand-rolled toggle idioms across the editors (clock H12/H24, seconds
+ * on/off, meridiem, …).
+ *
+ * Keyboard model: roving tabindex (only the active segment is in the
+ * tab order); Left/Up and Right/Down move + select the neighbour,
+ * Home/End jump to the ends. Visible focus ring on each segment.
+ */
+export function SegmentedToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  options: SegmentOption<T>[];
+  value: T;
+  onChange: (next: T) => void;
+  ariaLabel?: string;
+}) {
+  const groupId = useId();
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const move = (delta: number) => {
+    const idx = options.findIndex((o) => o.id === value);
+    const start = idx < 0 ? 0 : idx;
+    const next = (start + delta + options.length) % options.length;
+    onChange(options[next].id);
+    refs.current[next]?.focus();
+  };
+
+  const jump = (to: 0 | -1) => {
+    const next = to === 0 ? 0 : options.length - 1;
+    onChange(options[next].id);
+    refs.current[next]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        e.preventDefault();
+        move(1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        e.preventDefault();
+        move(-1);
+        break;
+      case "Home":
+        e.preventDefault();
+        jump(0);
+        break;
+      case "End":
+        e.preventDefault();
+        jump(-1);
+        break;
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      onKeyDown={onKeyDown}
+      className="flex items-center gap-px border border-(--color-border)"
+    >
+      {options.map((o, i) => {
+        const active = o.id === value;
+        return (
+          <button
+            key={o.id}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            id={`${groupId}-${o.id}`}
+            title={o.blurb}
+            onClick={() => onChange(o.id)}
+            className={[
+              "px-3 py-1 font-mono text-[10px] uppercase tracking-[0.3em] transition-colors",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
+              active
+                ? "bg-(--color-accent) text-black"
+                : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
+            ].join(" ")}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dash/src/app/components/SolidColorPicker.tsx
+++ b/dash/src/app/components/SolidColorPicker.tsx
@@ -4,27 +4,33 @@ import { useState } from "react";
 
 import { hexToRgb, rgbToHex, type Rgb } from "@/utils/color";
 
+/** Preset swatches wired to the `--color-swatch-*` tokens (globals.css)
+ * so the palette stays in one place. The resolved hexes match the
+ * token definitions; we keep them here for the rgb comparison + the
+ * `value` attribute without a getComputedStyle round-trip. */
 const PRESETS = [
-  { hex: "#FF8A2C", label: "amber" },
-  { hex: "#FF4D6D", label: "rose" },
-  { hex: "#FFE066", label: "sun" },
-  { hex: "#A6E22E", label: "lime" },
-  { hex: "#4DE0E0", label: "cyan" },
-  { hex: "#4DA3FF", label: "azure" },
-  { hex: "#A04DFF", label: "violet" },
-  { hex: "#FFFFFF", label: "white" },
+  { token: "--color-swatch-rose", hex: "#FF4D6D", label: "rose" },
+  { token: "--color-swatch-amber", hex: "#FF8A2C", label: "amber" },
+  { token: "--color-swatch-sun", hex: "#FFE066", label: "sun" },
+  { token: "--color-swatch-lime", hex: "#A6E22E", label: "lime" },
+  { token: "--color-swatch-cyan", hex: "#4DE0E0", label: "cyan" },
+  { token: "--color-swatch-azure", hex: "#4DA3FF", label: "azure" },
+  { token: "--color-swatch-violet", hex: "#A04DFF", label: "violet" },
+  { token: "--color-swatch-white", hex: "#FFFFFF", label: "white" },
 ];
 
 /**
  * Single-color picker shared across every scene composer that
- * needs to pick one Rgb value (clock, life, image-tint-tbd, etc.).
+ * needs to pick one Rgb value (clock, life, shapes, paint, …).
  * The text-mode `ColorPicker` (which adds a rainbow alternative)
  * delegates to this component for its rgb branch — there's exactly
  * one solid-color UX in the dash, in one place.
  *
  * UX: live swatch, hex text input, RGB readout, plus a preset grid.
- * Hex input keeps a draft string so partial typing doesn't fight
- * the parent's value; only commits on a fully-formed 6-digit hex.
+ * Hex input keeps a draft string so partial typing doesn't fight the
+ * parent's value; it only COMMITS on blur or Enter (not on every
+ * keystroke that happens to parse) so typing "#FF0" doesn't briefly
+ * jump the panel to red.
  */
 export function SolidColorPicker({
   value,
@@ -41,6 +47,18 @@ export function SolidColorPicker({
     setDraft(valueHex);
   }
 
+  // Commit the draft if it's a complete, parseable hex; otherwise
+  // snap the draft back to the committed value so the field never
+  // strands a half-typed string.
+  const commitDraft = () => {
+    const rgb = hexToRgb(draft);
+    if (rgb) {
+      onChange(rgb);
+    } else {
+      setDraft(valueHex);
+    }
+  };
+
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
@@ -55,11 +73,13 @@ export function SolidColorPicker({
         <input
           type="text"
           value={draft}
-          onChange={(e) => {
-            const next = e.target.value;
-            setDraft(next);
-            const rgb = hexToRgb(next);
-            if (rgb) onChange(rgb);
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitDraft}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitDraft();
+            }
           }}
           spellCheck={false}
           className="flex-1 border-0 border-b border-(--color-border-strong) bg-transparent p-0 pb-0.5 font-mono text-sm uppercase tracking-wider text-(--color-text) focus:border-(--color-accent) focus:outline-none focus:ring-0"
@@ -81,18 +101,19 @@ export function SolidColorPicker({
             rgb.r === value.r && rgb.g === value.g && rgb.b === value.b;
           return (
             <button
-              key={preset.hex}
+              key={preset.token}
               type="button"
               onClick={() => onChange(rgb)}
               className={[
                 "relative h-4 w-4 border transition",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)",
                 active
                   ? "border-(--color-text)"
                   : "border-(--color-border) hover:border-(--color-border-strong)",
               ].join(" ")}
-              style={{ backgroundColor: preset.hex }}
+              style={{ backgroundColor: `var(${preset.token})` }}
               title={`${preset.label} ${preset.hex}`}
-              aria-label={`Pick ${preset.hex}`}
+              aria-label={`Pick ${preset.label}`}
             >
               {active ? (
                 <span

--- a/dash/src/app/components/StatusBar.tsx
+++ b/dash/src/app/components/StatusBar.tsx
@@ -33,12 +33,26 @@ export function StatusBar({
   const queueDepth = useQueueDepth(panelId);
   const versionShort = driverVersion ? driverVersion.slice(0, 10) : "—";
 
+  // Each state carries a non-color glyph in addition to its hue and
+  // the (optional) animated lamp, so paused/offline/transmitting stay
+  // distinguishable for color-blind users and when the lamp is off.
   const beat = isPanelPaused
-    ? { label: "paused", tone: "text-(--color-amber)", lampClass: "" }
+    ? {
+        label: "paused",
+        glyph: "⏸",
+        tone: "text-(--color-amber)",
+        lampClass: "",
+      }
     : offline
-      ? { label: "offline", tone: "text-(--color-danger)", lampClass: "" }
+      ? {
+          label: "offline",
+          glyph: "✕",
+          tone: "text-(--color-danger)",
+          lampClass: "",
+        }
       : {
           label: "transmitting",
+          glyph: "●",
           tone: "text-(--color-phosphor)",
           lampClass: "animate-pulse bg-(--color-phosphor)",
         };
@@ -59,6 +73,16 @@ export function StatusBar({
           label="state"
           value={beat.label}
           valueClass={beat.tone}
+          // role="status" makes this a valid aria-live region (a bare
+          // div + aria-label is aria-prohibited). The visible "state"
+          // label + value carry the accessible name, so it announces
+          // once — no aria-label needed (which would double-announce).
+          role="status"
+          prefix={
+            <span aria-hidden className="mr-1 leading-none">
+              {beat.glyph}
+            </span>
+          }
           suffix={
             beat.lampClass ? (
               <span
@@ -110,7 +134,9 @@ function Cell({
   accent,
   muted,
   mono,
+  prefix,
   suffix,
+  role,
   className,
 }: {
   label: string;
@@ -120,17 +146,25 @@ function Cell({
   muted?: boolean;
   /** When true, render value in mono (raw) instead of pixel font. */
   mono?: boolean;
+  prefix?: React.ReactNode;
   suffix?: React.ReactNode;
+  /** ARIA role for the cell (e.g. "status" for the live state cell).
+   * The visible label + value carry the accessible name, so no
+   * aria-label is set — that would double-announce. */
+  role?: React.AriaRole;
   className?: string;
 }) {
   return (
     <div
+      role={role}
       className={[
         "flex items-center gap-2 px-3",
         className ?? "",
       ].join(" ")}
     >
-      <span className="font-mono text-[9px] leading-none uppercase tracking-[0.3em] text-(--color-text-dim)">
+      <span
+        className="font-mono text-[9px] leading-none uppercase tracking-[0.3em] text-(--color-text-dim)"
+      >
         {label}
       </span>
       <span
@@ -156,6 +190,7 @@ function Cell({
               }
         }
       >
+        {prefix}
         <span className="truncate">{value}</span>
         {suffix}
       </span>

--- a/dash/src/app/error.tsx
+++ b/dash/src/app/error.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Route-root error boundary. A malformed `mode_config` (or any render
+ * throw) is contained here instead of blanking the whole dashboard.
+ * Styled to match the dark instrument chrome; offers a reset that
+ * re-attempts the failed render subtree.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Surface for diagnostics — the boundary swallows it otherwise.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-6xl flex-col items-center justify-center px-4 sm:px-6 lg:px-10">
+      <section
+        role="alert"
+        aria-label="Dashboard error"
+        className="relative w-full max-w-md border border-(--color-danger)/40 bg-(--color-surface)/70 backdrop-blur-sm"
+      >
+        <header className="flex items-center justify-between border-b border-(--color-danger)/30 bg-(--color-danger)/5 px-4 py-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-danger)">
+            :: fault
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
+            render halted
+          </span>
+        </header>
+
+        <div className="space-y-4 px-4 py-5">
+          <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
+            the dashboard hit an unrecoverable error
+          </p>
+          <p className="break-words font-mono text-xs text-(--color-text-muted)">
+            {error.message || "unknown error"}
+            {error.digest ? (
+              <span className="ml-2 text-(--color-text-faint)">
+                · {error.digest}
+              </span>
+            ) : null}
+          </p>
+
+          <button
+            type="button"
+            onClick={reset}
+            className="group flex w-full items-center justify-between overflow-hidden border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-3 text-(--color-accent) transition hover:bg-(--color-accent)/20"
+          >
+            <span className="flex items-center gap-3">
+              <span
+                aria-hidden
+                className="flex h-6 w-6 items-center justify-center border border-(--color-accent)/40"
+                style={{
+                  fontFamily: "var(--font-pixel)",
+                  fontSize: 16,
+                  lineHeight: 1,
+                }}
+              >
+                ↻
+              </span>
+              <span className="font-mono text-xs uppercase tracking-[0.4em]">
+                retry
+              </span>
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.25em] opacity-70">
+              re-render
+            </span>
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/dash/src/app/page.tsx
+++ b/dash/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import { PowerIcon } from "@heroicons/react/24/outline";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSWRConfig } from "swr";
 
 import { Composer } from "@/app/components/Composer";
 import { type ColorState } from "@/app/components/ColorPicker";
@@ -14,7 +13,10 @@ import {
 import { EntriesList } from "@/app/components/EntriesList";
 import { InstrumentHeader } from "@/app/components/InstrumentHeader";
 import { MatrixPreview } from "@/app/components/MatrixPreview";
-import { PanelSwitcher } from "@/app/components/PanelSwitcher";
+import {
+  PANEL_CONTENT_ID,
+  PanelSwitcher,
+} from "@/app/components/PanelSwitcher";
 import { StatusBar } from "@/app/components/StatusBar";
 import { PanelContext } from "@/app/context";
 import { SCENES } from "@/app/scenes";
@@ -34,7 +36,6 @@ const AUTO_FORCED_DEFAULT = 10;
 
 export default function Page() {
   const realtimeStatus = useRealtimeRevalidation();
-  const { mutate } = useSWRConfig();
   const { data: panelsData } = panels.get.useSWR();
 
   const [chosenPanelId, setChosenPanelId] = useState<string | null>(null);
@@ -52,14 +53,20 @@ export default function Page() {
     setChosenPanelId(null);
   }
   const panelId = chosenPanelId ?? defaultPanelId;
-  const activePanel = panelsData?.find((p) => p.id === panelId);
 
-  // Resolve the active mode against the SCENES registry. Anything
-  // unknown falls through to text mode.
-  const activeMode: PanelMode = MODES.some((m) => m.id === activePanel?.mode)
-    ? (activePanel!.mode as PanelMode)
-    : "text";
+  // Resolve the active panel + its mode in one pass instead of
+  // re-scanning panelsData with find/some/find every render. Unknown
+  // modes fall through to text.
+  const { activePanel, activeMode } = useMemo(() => {
+    const panel = panelsData?.find((p) => p.id === panelId);
+    const mode: PanelMode = MODES.some((m) => m.id === panel?.mode)
+      ? (panel!.mode as PanelMode)
+      : "text";
+    return { activePanel: panel, activeMode: mode };
+  }, [panelsData, panelId]);
   const frame = SCENES[activeMode];
+
+  const hasPanels = (panelsData?.length ?? 0) > 0;
 
   // 1Hz tick for the clock simulator + offline indicator.
   const now = useNow(1_000);
@@ -72,18 +79,39 @@ export default function Page() {
     rgb: { r: 255, g: 138, b: 44 },
   });
   const [effects, setEffects] = useState<EffectsState>({ marqueeSpeed: 0 });
+  const [submitError, setSubmitError] = useState(false);
+
+  // Switching panels starts a fresh composition. Reset composer effects
+  // (so one panel's auto-forced marquee doesn't bleed into the next) and
+  // clear any stale transmit-failure flag — done during render via the
+  // documented "adjust state when a prop changes" pattern (matches the
+  // chosenPanelId reset above), keeping it out of an effect.
+  const [effectsPanelId, setEffectsPanelId] = useState(panelId);
+  if (effectsPanelId !== panelId) {
+    setEffectsPanelId(panelId);
+    setEffects({ marqueeSpeed: 0 });
+    setSubmitError(false);
+  }
 
   const isSubmittable =
     activeMode === "text" && message.length > 0 && panelId.length > 0;
   const isMarqueeForced = message.length >= FORCE_ENABLE_MARQUEE_LENGTH;
 
   const wasForced = useRef(false);
+
   useEffect(() => {
     if (isMarqueeForced && !wasForced.current && effects.marqueeSpeed === 0) {
       setEffects((e) => ({ ...e, marqueeSpeed: AUTO_FORCED_DEFAULT }));
     }
     wasForced.current = isMarqueeForced;
   }, [isMarqueeForced, effects.marqueeSpeed]);
+
+  // Clear the auto-force latch when the panel changes so the next
+  // panel's first long message re-applies the default marquee speed.
+  // (Ref writes belong in an effect, not in render.)
+  useEffect(() => {
+    wasForced.current = false;
+  }, [panelId]);
 
   const effectiveMarqueeSpeed =
     isMarqueeForced && effects.marqueeSpeed === 0
@@ -101,16 +129,26 @@ export default function Page() {
               speed: color.speed,
             },
           };
-    await entries.add.call(panelId, {
-      text: message,
-      options: {
-        color: wireColor,
-        marquee: { speed: effectiveMarqueeSpeed },
-      },
-    });
+    setSubmitError(false);
+    try {
+      // actions.ts inserts optimistically + rolls back on error, so the
+      // queue updates instantly and no manual mutate is needed.
+      await entries.add.call(panelId, {
+        text: message,
+        options: {
+          color: wireColor,
+          marquee: { speed: effectiveMarqueeSpeed },
+        },
+      });
+    } catch (e) {
+      setSubmitError(true);
+      // Re-throw so the Composer keeps the message + skips its
+      // success-only input refocus.
+      throw e;
+    }
+    // Only clear the payload once the transmit is confirmed.
     setMessage("");
-    await mutate(`/entries/${panelId}`);
-  }, [color, message, mutate, panelId, effectiveMarqueeSpeed]);
+  }, [color, message, panelId, effectiveMarqueeSpeed]);
 
   // Parse the active mode's config once per mode_config change. Only
   // the active mode's parser runs.
@@ -163,9 +201,18 @@ export default function Page() {
         <InstrumentHeader realtimeStatus={realtimeStatus} />
 
         {/* ─── instrument: matrix simulator ──────────────────────── */}
+        {/* This section is the tabpanel the PanelSwitcher tabs drive
+          * (each tab's aria-controls points at PANEL_CONTENT_ID). When a
+          * panel is selected we label it by its tab; otherwise a static
+          * label so AT still announces the region. */}
         <section
+          id={PANEL_CONTENT_ID}
+          role="tabpanel"
+          aria-label={hasPanels && panelId ? undefined : "Live simulator"}
+          aria-labelledby={
+            hasPanels && panelId ? `panel-tab-${panelId}` : undefined
+          }
           className="grid gap-4 lg:grid-cols-[1fr_240px]"
-          aria-label="Live simulator"
         >
           <div className="relative">
             {/* Section heading plate — instrument-label feel */}
@@ -288,12 +335,25 @@ export default function Page() {
               <CornerBracket pos="tr" size="lg" />
               <CornerBracket pos="bl" size="lg" />
               <CornerBracket pos="br" size="lg" />
-              <MatrixPreview
-                offline={activePanelOffline}
-                mode={modeFrame}
-                isPaused={activePanel?.is_paused ?? false}
-                isOff={activePanel?.is_off ?? false}
-              />
+              {hasPanels ? (
+                <MatrixPreview
+                  offline={activePanelOffline}
+                  mode={modeFrame}
+                  isPaused={activePanel?.is_paused ?? false}
+                  isOff={activePanel?.is_off ?? false}
+                />
+              ) : (
+                // No panels registered — an offline simulator here would
+                // read as a broken panel rather than an empty fleet.
+                <div className="flex aspect-square w-full flex-col items-center justify-center gap-2 rounded-2xl border border-(--color-border) bg-black text-center font-mono uppercase tracking-[0.3em]">
+                  <span className="text-[11px] text-(--color-text-dim)">
+                    no panels registered
+                  </span>
+                  <span className="text-[9px] text-(--color-text-faint)">
+                    connect a driver to begin
+                  </span>
+                </div>
+              )}
             </div>
           </div>
 
@@ -316,13 +376,18 @@ export default function Page() {
           <div className="grid flex-1 gap-6 lg:grid-cols-[1fr_1fr]">
             <Composer
               message={message}
-              onMessageChange={setMessage}
+              onMessageChange={(s) => {
+                // Editing the payload clears a stale transmit failure.
+                if (submitError) setSubmitError(false);
+                setMessage(s);
+              }}
               color={color}
               onColorChange={setColor}
               effects={effects}
               onEffectsChange={setEffects}
               onSubmit={handleSubmit}
               disabled={!isSubmittable}
+              transmitFailed={submitError}
             />
             <section
               className="flex min-h-0 flex-col gap-3"

--- a/dash/src/app/scenes/ModeSwitcher.tsx
+++ b/dash/src/app/scenes/ModeSwitcher.tsx
@@ -16,9 +16,21 @@ import { MODES } from "./types";
 import { panels, type PanelMode } from "@/utils/actions";
 
 /**
- * Segmented mode picker. Switching writes the new mode + an empty
- * mode_config to Supabase; per-mode forms hydrate their own defaults
- * if config is missing/partial.
+ * Per-mode config cache, module-scoped so it survives this component's
+ * remounts within a session. Keyed by `panelId:mode`. The DB stores a
+ * single `mode_config` column shared across modes, so naively writing
+ * `{}` on every switch wiped the outgoing editor's work. We instead
+ * stash the outgoing mode's config here on switch and restore the
+ * incoming mode's last-known config (if we've seen it), so toggling
+ * modes back and forth no longer destroys the previous editor's state.
+ */
+const configCache = new Map<string, Record<string, unknown>>();
+const cacheKey = (panelId: string, mode: PanelMode) => `${panelId}:${mode}`;
+
+/**
+ * Segmented mode picker. Switching preserves per-mode config across
+ * toggles (see `configCache`); per-mode forms still hydrate their own
+ * defaults if config is missing/partial.
  *
  * Each tile is a "preset key" — heroicon glyph, label, and short
  * blurb. Active tile gets a recessed/illuminated treatment; inactive
@@ -31,6 +43,26 @@ export function ModeSwitcher({
   panelId: string;
   current: PanelMode;
 }) {
+  // Read the live panel row from the SWR cache (already subscribed at
+  // the page root) so we can snapshot the OUTGOING mode's config
+  // before we switch away from it.
+  const { data: allPanels } = panels.get.useSWR();
+  const currentConfig =
+    (allPanels?.find((p) => p.id === panelId)?.mode_config as
+      | Record<string, unknown>
+      | null
+      | undefined) ?? null;
+
+  const switchTo = (next: PanelMode) => {
+    // Snapshot what's currently persisted under the outgoing mode so a
+    // later switch back restores it rather than the empty default.
+    if (currentConfig && Object.keys(currentConfig).length > 0) {
+      configCache.set(cacheKey(panelId, current), currentConfig);
+    }
+    const restored = configCache.get(cacheKey(panelId, next)) ?? {};
+    void panels.setMode.call(panelId, next, restored);
+  };
+
   return (
     <div
       role="tablist"
@@ -48,7 +80,7 @@ export function ModeSwitcher({
             aria-selected={active}
             onClick={() => {
               if (active) return;
-              void panels.setMode.call(panelId, m.id, {});
+              switchTo(m.id);
             }}
             // Even-rows wrap: each tile takes a slightly-less-than-25%
             // basis so a row of 4 fits exactly even with the
@@ -92,7 +124,7 @@ export function ModeSwitcher({
                 className={[
                   "truncate font-mono text-[9px] tracking-wide",
                   active
-                    ? "text-(--color-accent)/70"
+                    ? "text-(--color-accent)"
                     : "text-(--color-text-faint)",
                 ].join(" ")}
               >

--- a/dash/src/app/scenes/clock.tsx
+++ b/dash/src/app/scenes/clock.tsx
@@ -12,13 +12,14 @@ import { useMemo, useState } from "react";
 import {
   type ClockSceneConfig,
   type ClockScene,
+  defaultClockConfig,
   DEFAULT_CLOCK_CONFIG,
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { SegmentedToggle } from "@/app/components/SegmentedToggle";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
-import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
-import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
+import { useComposerConfig } from "@/utils/useComposerConfig";
 
 /** Build a renderable clock frame from saved config + current time. */
 export function clockSceneFromConfig(config: ClockSceneConfig): ClockScene {
@@ -65,7 +66,7 @@ function sampleTime(timezone: string | null) {
 
 /** Read a stored mode_config jsonb back into a typed `ClockSceneConfig`. */
 export function parseClockConfig(raw: unknown): ClockSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_CLOCK_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultClockConfig();
   const obj = raw as Record<string, unknown>;
   const fmt = obj.format === "H12" ? "H12" : "H24";
   const colorRaw =
@@ -78,7 +79,7 @@ export function parseClockConfig(raw: unknown): ClockSceneConfig {
         g: clamp255(colorRaw.g),
         b: clamp255(colorRaw.b),
       }
-    : DEFAULT_CLOCK_CONFIG.color;
+    : { ...DEFAULT_CLOCK_CONFIG.color };
   const timezone =
     typeof obj.timezone === "string" && obj.timezone.length > 0
       ? obj.timezone
@@ -109,70 +110,65 @@ export function ClockComposer({
   panelId: string;
   config: ClockSceneConfig;
 }) {
-  // Local copy keeps the form responsive against the 30s last_seen
-  // heartbeat refreshes; resyncs only when the server's config bytes
-  // actually change.
-  const [local, setLocal] = useSyncedFromProp(JSON.stringify(config), config);
-
-  const [pushDebounced] = useDebouncedSetMode<ClockSceneConfig>(
+  // Editable local mirror + debounced persist, keyed on the stable
+  // panelId:mode identity so a server echo doesn't snap the form.
+  const [draft, update] = useComposerConfig<ClockSceneConfig>(
     panelId,
     "clock",
+    config,
   );
-  const persist = (next: ClockSceneConfig) => {
-    setLocal(next);
-    pushDebounced(next);
-  };
 
   return (
     <ComposerShell title="clock" status="local time" ariaLabel="Clock configuration">
       <div className="space-y-5 px-4 py-4">
         <Row label="format">
-          <SegmentedToggle
+          <SegmentedToggle<"H12" | "H24">
+            ariaLabel="Time format"
             options={[
               { id: "H24", label: "24h" },
               { id: "H12", label: "12h" },
             ]}
-            value={local.format}
-            onChange={(v) => persist({ ...local, format: v as "H12" | "H24" })}
+            value={draft.format}
+            onChange={(format) => update({ ...draft, format })}
           />
         </Row>
 
         <Row label="seconds">
           <SegmentedToggle
+            ariaLabel="Show seconds"
             options={[
               { id: "off", label: "off" },
               { id: "on", label: "on" },
             ]}
-            value={local.show_seconds ? "on" : "off"}
-            onChange={(v) => persist({ ...local, show_seconds: v === "on" })}
+            value={draft.show_seconds ? "on" : "off"}
+            onChange={(v) => update({ ...draft, show_seconds: v === "on" })}
           />
         </Row>
 
-        {local.format === "H12" ? (
+        {draft.format === "H12" ? (
           <Row label="meridiem">
             <SegmentedToggle
+              ariaLabel="Show meridiem"
               options={[
                 { id: "off", label: "hidden" },
                 { id: "on", label: "a/p" },
               ]}
-              value={local.show_meridiem ? "on" : "off"}
-              onChange={(v) =>
-                persist({ ...local, show_meridiem: v === "on" })
-              }
+              value={draft.show_meridiem ? "on" : "off"}
+              onChange={(v) => update({ ...draft, show_meridiem: v === "on" })}
             />
           </Row>
         ) : null}
 
         <Row label="timezone">
           <TimezoneSelect
-            value={local.timezone}
-            onChange={(next) => persist({ ...local, timezone: next })}
+            value={draft.timezone}
+            onChange={(timezone) => update({ ...draft, timezone })}
           />
         </Row>
 
         <SolidColorPicker
-          value={local.color}
-          onChange={(next) => persist({ ...local, color: next })}
+          value={draft.color}
+          onChange={(color) => update({ ...draft, color })}
         />
       </div>
     </ComposerShell>
@@ -285,36 +281,4 @@ function TimezoneSelect({
   );
 }
 
-function SegmentedToggle({
-  options,
-  value,
-  onChange,
-}: {
-  options: { id: string; label: string }[];
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <div className="flex items-center gap-px border border-(--color-border)">
-      {options.map((o) => {
-        const active = o.id === value;
-        return (
-          <button
-            key={o.id}
-            type="button"
-            onClick={() => onChange(o.id)}
-            className={[
-              "px-3 py-1 font-mono text-[10px] uppercase tracking-[0.3em] transition-colors",
-              active
-                ? "bg-(--color-accent) text-black"
-                : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
-            ].join(" ")}
-          >
-            {o.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
 

--- a/dash/src/app/scenes/gif.tsx
+++ b/dash/src/app/scenes/gif.tsx
@@ -4,28 +4,33 @@ import { parseGIF, decompressFrames, type ParsedFrame } from "gifuct-js";
 import { useRef, useState } from "react";
 
 import {
-  DEFAULT_GIF_CONFIG,
+  defaultGifConfig,
   type GifFrame,
   type GifSceneConfig,
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { Fader } from "@/app/components/Fader";
 import { panels } from "@/utils/actions";
 import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
 
 const PANEL_W = 64;
 const PANEL_H = 64;
-// Cap at 60; Supabase update latency degrades past ~120.
+// Cap frame count: each frame is ~16KB of RGBA bytes and the whole
+// payload is JSON-stringified into mode_config, so Supabase write
+// latency climbs roughly linearly with frame count past this point.
 const MAX_FRAMES = 60;
 // Defensive floor — some gifs ship 0ms delays.
 const MIN_DELAY_MS = 20;
 
 export function parseGifConfig(raw: unknown): GifSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_GIF_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultGifConfig();
   const obj = raw as Record<string, unknown>;
   const width = typeof obj.width === "number" ? obj.width : 0;
   const height = typeof obj.height === "number" ? obj.height : 0;
   const framesRaw = Array.isArray(obj.frames) ? obj.frames : [];
+  // RGBA, 4-byte stride: each frame's bitmap is exactly 4 * w * h
+  // (matches display_core::frames::gif::GifFrame).
   const expectedLen = width * height * 4;
   const frames: GifFrame[] = [];
   for (const f of framesRaw) {
@@ -37,10 +42,13 @@ export function parseGifConfig(raw: unknown): GifSceneConfig {
     frames.push({ bitmap, delay_ms: Math.max(MIN_DELAY_MS, delay) });
   }
   if (width <= 0 || height <= 0 || frames.length === 0) {
-    return DEFAULT_GIF_CONFIG;
+    return defaultGifConfig();
   }
+  // Clamp uniformly to the driver's render range [0.05, 16]; only a
+  // missing/non-numeric speed falls back to 1. A stored 0 clamps up
+  // to the slider floor (0.05), consistent with the driver's clamp.
   const speed =
-    typeof obj.speed === "number" && obj.speed > 0
+    typeof obj.speed === "number"
       ? Math.max(0.05, Math.min(16, obj.speed))
       : 1;
   const source = typeof obj.source === "string" ? obj.source : undefined;
@@ -52,9 +60,10 @@ export function parseGifConfig(raw: unknown): GifSceneConfig {
 }
 
 /**
- * Decode an uploaded GIF into a sequence of fixed-size RGB888 frames.
- * gifuct-js gives us patches per frame plus disposal/dims metadata;
- * we composite onto a working canvas to resolve disposal correctly,
+ * Decode an uploaded GIF into a sequence of fixed-size RGBA frames
+ * (4-byte stride; what the Rust/WASM renderer expects). gifuct-js
+ * gives us patches per frame plus disposal/dims metadata; we
+ * composite onto a working canvas to resolve disposal correctly,
  * downsample to PANEL_W × PANEL_H (centered, fit), then snapshot.
  */
 async function decodeGif(file: File): Promise<GifSceneConfig> {
@@ -91,30 +100,36 @@ async function decodeGif(file: File): Promise<GifSceneConfig> {
   octx.imageSmoothingQuality = "high";
 
   const frames: GifFrame[] = [];
-  let prevImage: ImageData | null = null;
+  // Snapshot of the working canvas taken immediately BEFORE the
+  // previous frame's patch was drawn. GIF disposal method 3
+  // ("restore to previous") requires reverting to exactly that state
+  // — NOT to a rolling buffer that already has the previous frame's
+  // pixels composited in (which drifts on chained type-3 frames).
+  let preDrawSnapshot: ImageData | null = null;
 
   const limit = Math.min(parsed.length, MAX_FRAMES);
   for (let fi = 0; fi < limit; fi++) {
     const frame = parsed[fi];
 
     // Apply disposal of the *previous* frame before drawing this one.
-    if (prevImage && fi > 0) {
+    if (fi > 0) {
       const prev = parsed[fi - 1];
       if (prev.disposalType === 2) {
         // Restore to background = clear that frame's region.
         const d = prev.dims;
         wctx.clearRect(d.left, d.top, d.width, d.height);
-      } else if (prev.disposalType === 3) {
-        // Restore to previous: paint back what was there before.
-        wctx.putImageData(prevImage, 0, 0);
+      } else if (prev.disposalType === 3 && preDrawSnapshot) {
+        // Restore to previous: revert the whole canvas to the state
+        // captured right before the previous frame was drawn.
+        wctx.putImageData(preDrawSnapshot, 0, 0);
       }
       // disposal 0/1: leave in place.
     }
 
     // Snapshot the working buffer *before* drawing this frame's
-    // patch — needed for "restore to previous" disposal handling on
-    // the next iteration.
-    prevImage = wctx.getImageData(0, 0, work.width, work.height);
+    // patch — this is the state a following frame with disposal
+    // type 3 ("restore to previous") must revert to.
+    preDrawSnapshot = wctx.getImageData(0, 0, work.width, work.height);
 
     // Paint this frame's patch.
     const patch = new ImageData(
@@ -142,10 +157,9 @@ async function decodeGif(file: File): Promise<GifSceneConfig> {
     octx.drawImage(work, 0, 0, drawW, drawH);
     const data = octx.getImageData(0, 0, drawW, drawH).data;
 
-    const bitmap = new Array<number>(drawW * drawH * 4);
-    for (let i = 0; i < data.length; i++) {
-      bitmap[i] = data[i];
-    }
+    // Bulk-copy the RGBA Uint8ClampedArray; Array.from is far faster
+    // than a per-byte assignment loop over ~16K elements per frame.
+    const bitmap = Array.from(data);
     // Per-frame delay: gifuct returns delay in 1/100s units.
     const delay_ms = Math.max(MIN_DELAY_MS, (frame.delay ?? 10) * 10);
     frames.push({ bitmap, delay_ms });
@@ -267,7 +281,19 @@ export function GifComposer({
           <>
             <div className="border-t border-dashed border-(--color-hairline)" />
 
-            <SpeedRow value={config.speed} onChange={setSpeed} />
+            <Fader
+              label="// speed"
+              value={config.speed}
+              min={SPEED_PRESETS[0]}
+              max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
+              step={0.05}
+              onChange={setSpeed}
+              format={(v) => `${v.toFixed(2)}x`}
+              endpoints={["slow", "fast"]}
+              presets={SPEED_PRESETS}
+              presetLabel={(v) => `${v}x`}
+              ariaLabel="GIF speed"
+            />
 
             <div className="border-t border-dashed border-(--color-hairline)" />
 
@@ -296,75 +322,6 @@ export function GifComposer({
         ) : null}
       </div>
     </ComposerShell>
-  );
-}
-
-function SpeedRow({
-  value,
-  onChange,
-}: {
-  value: number;
-  onChange: (next: number) => void;
-}) {
-  // Min slider step so dragging feels smooth; presets are markers.
-  const min = SPEED_PRESETS[0];
-  const max = SPEED_PRESETS[SPEED_PRESETS.length - 1];
-  const pct = ((value - min) / (max - min)) * 100;
-  return (
-    <div className="space-y-2.5">
-      <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          {"// speed"}
-        </span>
-        <span
-          className="tabular-nums text-(--color-text)"
-          style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-        >
-          {value.toFixed(2)}x
-        </span>
-      </div>
-
-      <div className="flex items-center gap-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-          slow
-        </span>
-        <input
-          type="range"
-          min={min}
-          max={max}
-          step={0.05}
-          value={value}
-          onChange={(e) => onChange(Number(e.target.value))}
-          className="fader flex-1"
-          style={{ ["--fader-pos" as string]: `${pct}%` } as React.CSSProperties}
-          aria-label="GIF speed"
-        />
-        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-          fast
-        </span>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-1">
-        {SPEED_PRESETS.map((p) => {
-          const active = Math.abs(value - p) < 0.01;
-          return (
-            <button
-              key={p}
-              type="button"
-              onClick={() => onChange(p)}
-              className={[
-                "border px-2 py-1 font-mono text-[9px] uppercase tracking-[0.25em] transition-colors",
-                active
-                  ? "border-(--color-accent) bg-(--color-accent)/15 text-(--color-accent)"
-                  : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",
-              ].join(" ")}
-            >
-              {p}x
-            </button>
-          );
-        })}
-      </div>
-    </div>
   );
 }
 

--- a/dash/src/app/scenes/image.tsx
+++ b/dash/src/app/scenes/image.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 
 import {
-  DEFAULT_IMAGE_CONFIG,
+  defaultImageConfig,
   type ImageSceneConfig,
 } from "./types";
 
@@ -14,21 +14,25 @@ const PANEL_W = 64;
 const PANEL_H = 64;
 
 export function parseImageConfig(raw: unknown): ImageSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_IMAGE_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultImageConfig();
   const obj = raw as Record<string, unknown>;
   const width = typeof obj.width === "number" ? obj.width : 0;
   const height = typeof obj.height === "number" ? obj.height : 0;
   const bitmap = Array.isArray(obj.bitmap) ? (obj.bitmap as number[]) : [];
   const source = typeof obj.source === "string" ? obj.source : undefined;
+  // RGBA, 4-byte stride: length must be exactly 4 * width * height
+  // (matches display_core::frames::image::ImageScene).
   if (bitmap.length === 0 || bitmap.length !== width * height * 4) {
-    return DEFAULT_IMAGE_CONFIG;
+    return defaultImageConfig();
   }
   return { width, height, bitmap, source };
 }
 
 /**
  * Read an image from a URL or File, downsample (fit + center) to
- * panel dims, and return RGBA row-major bytes.
+ * panel dims, and return RGBA row-major bytes (4-byte stride). The
+ * Rust/WASM renderer treats alpha as binary — any non-zero alpha
+ * renders at full intensity, alpha 0 leaves the LED unset.
  */
 async function loadAndDownsample(
   src: string | File,
@@ -48,14 +52,13 @@ async function loadAndDownsample(
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = "high";
     ctx.drawImage(img, 0, 0, drawW, drawH);
-    // ImageData is already RGBA. Treat the source's alpha as binary
-    // (panels have no PWM blending against the background): any
-    // non-zero alpha → fully opaque on the panel.
+    // ImageData is already RGBA (matches the renderer's expected
+    // 4-byte stride). Treat the source's alpha as binary (panels have
+    // no PWM blending against the background): any non-zero alpha →
+    // fully opaque on the panel. Array.from bulk-copies the
+    // Uint8ClampedArray far faster than a per-byte assignment loop.
     const data = ctx.getImageData(0, 0, drawW, drawH).data;
-    const bitmap: number[] = new Array(drawW * drawH * 4);
-    for (let i = 0; i < data.length; i++) {
-      bitmap[i] = data[i];
-    }
+    const bitmap = Array.from(data);
     return {
       width: drawW,
       height: drawH,

--- a/dash/src/app/scenes/index.ts
+++ b/dash/src/app/scenes/index.ts
@@ -19,7 +19,7 @@ import {
 import { GifComposer, parseGifConfig } from "./gif";
 import { ImageComposer, parseImageConfig } from "./image";
 import { LifeComposer, parseLifeConfig } from "./life";
-import { PaintComposer, parsePaintConfig } from "./paint";
+import { PaintComposer, parsePaintConfig, type PaintSceneConfig } from "./paint";
 import { parseShapesConfig, ShapesComposer } from "./shapes";
 import { parseTestConfig, TestComposer } from "./test";
 import type {
@@ -143,8 +143,9 @@ export const SCENES: Record<PanelMode, SceneRegistration> = {
   ),
 
   // Paint shares Image's render path on both sides of the wire — the
-  // distinction lives entirely in this composer's UX.
-  paint: scene<ImageSceneConfig>(
+  // distinction lives entirely in this composer's UX. Paint also
+  // persists a sticky brush `color` the renderer ignores.
+  paint: scene<PaintSceneConfig>(
     parsePaintConfig,
     (config) => ({
       Image: {

--- a/dash/src/app/scenes/life.tsx
+++ b/dash/src/app/scenes/life.tsx
@@ -4,14 +4,15 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   DEFAULT_LIFE_CONFIG,
+  defaultLifeConfig,
   type LifeSceneConfig,
   type LifeScene,
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { SegmentedToggle } from "@/app/components/SegmentedToggle";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
-import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
-import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
+import { useComposerConfig } from "@/utils/useComposerConfig";
 
 const W = 64;
 const H = 64;
@@ -27,7 +28,7 @@ const SPEED_PRESETS: { id: string; label: string; frames: number }[] = [
 ];
 
 export function parseLifeConfig(raw: unknown): LifeSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_LIFE_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultLifeConfig();
   const obj = raw as Record<string, unknown>;
   const colorRaw =
     obj.color && typeof obj.color === "object"
@@ -39,7 +40,7 @@ export function parseLifeConfig(raw: unknown): LifeSceneConfig {
         g: clamp255(colorRaw.g),
         b: clamp255(colorRaw.b),
       }
-    : DEFAULT_LIFE_CONFIG.color;
+    : { ...DEFAULT_LIFE_CONFIG.color };
   const stepRaw =
     typeof obj.step_interval_frames === "number" ? obj.step_interval_frames : 0;
   const step =
@@ -70,13 +71,21 @@ export function useLifeScene(config: LifeSceneConfig): LifeScene {
   const generationsRef = useRef(0);
   const recentPopRef = useRef<number[]>([0, 0, 0, 0]);
   // Read step_interval_frames via ref so the loop closure picks up
-  // changes without re-arming requestAnimationFrame.
-  const intervalRef = useRef(config.step_interval_frames);
-  intervalRef.current = Math.max(1, config.step_interval_frames);
+  // changes without re-arming requestAnimationFrame. Synced in an
+  // effect — writing a ref during render is a React anti-pattern
+  // (and a lint error): the value isn't needed until the next frame.
+  const intervalRef = useRef(Math.max(1, config.step_interval_frames));
+  useEffect(() => {
+    intervalRef.current = Math.max(1, config.step_interval_frames);
+  }, [config.step_interval_frames]);
 
+  // The hook only mounts while life is the active mode, so the loop is
+  // already scoped to "visible". We additionally suspend it while the
+  // tab is hidden — rAF throttles in the background but we skip the
+  // simulation work entirely so a backgrounded tab does zero ticking.
   useEffect(() => {
     let raf = 0;
-    const loop = () => {
+    const tick = () => {
       framesRef.current += 1;
       if (framesRef.current >= intervalRef.current) {
         framesRef.current = 0;
@@ -100,6 +109,9 @@ export function useLifeScene(config: LifeSceneConfig): LifeScene {
           return next;
         });
       }
+    };
+    const loop = () => {
+      if (!document.hidden) tick();
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
@@ -150,7 +162,7 @@ function step(cells: Uint8Array): Uint8Array {
   return next;
 }
 
-/** Composer for life mode — just a color picker for the live cells. */
+/** Composer for life mode — speed preset + color for the live cells. */
 export function LifeComposer({
   panelId,
   config,
@@ -158,20 +170,19 @@ export function LifeComposer({
   panelId: string;
   config: LifeSceneConfig;
 }) {
-  const [local, setLocal] = useSyncedFromProp(JSON.stringify(config), config);
-  const [pushDebounced] = useDebouncedSetMode<LifeSceneConfig>(panelId, "life");
-  const persist = (next: LifeSceneConfig) => {
-    setLocal(next);
-    pushDebounced(next);
-  };
+  const [draft, update] = useComposerConfig<LifeSceneConfig>(
+    panelId,
+    "life",
+    config,
+  );
 
   // Map current step interval to the closest preset; if it doesn't
   // match exactly, the closest one still highlights for context.
   const activePreset =
-    SPEED_PRESETS.find((p) => p.frames === local.step_interval_frames)?.id ??
+    SPEED_PRESETS.find((p) => p.frames === draft.step_interval_frames)?.id ??
     SPEED_PRESETS.reduce((best, p) =>
-      Math.abs(p.frames - local.step_interval_frames) <
-      Math.abs(best.frames - local.step_interval_frames)
+      Math.abs(p.frames - draft.step_interval_frames) <
+      Math.abs(best.frames - draft.step_interval_frames)
         ? p
         : best,
     ).id;
@@ -187,30 +198,20 @@ export function LifeComposer({
           <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
             :: speed
           </span>
-          <div className="flex items-center gap-px border border-(--color-border)">
-            {SPEED_PRESETS.map((p) => {
-              const active = p.id === activePreset;
-              return (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => persist({ ...local, step_interval_frames: p.frames })}
-                  className={[
-                    "px-3 py-1 font-mono text-[10px] uppercase tracking-[0.3em] transition-colors",
-                    active
-                      ? "bg-(--color-accent) text-black"
-                      : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
-                  ].join(" ")}
-                >
-                  {p.label}
-                </button>
-              );
-            })}
-          </div>
+          <SegmentedToggle
+            ariaLabel="Simulation speed"
+            options={SPEED_PRESETS.map((p) => ({ id: p.id, label: p.label }))}
+            value={activePreset}
+            onChange={(id) => {
+              const preset = SPEED_PRESETS.find((p) => p.id === id);
+              if (preset)
+                update({ ...draft, step_interval_frames: preset.frames });
+            }}
+          />
         </div>
         <SolidColorPicker
-          value={local.color}
-          onChange={(next) => persist({ ...local, color: next })}
+          value={draft.color}
+          onChange={(color) => update({ ...draft, color })}
         />
       </div>
     </ComposerShell>

--- a/dash/src/app/scenes/paint.tsx
+++ b/dash/src/app/scenes/paint.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import {
-  type ImageSceneConfig,
-} from "./types";
+import { parseImageConfig } from "./image";
+import { type ImageSceneConfig } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
@@ -14,14 +13,35 @@ import { type Rgb } from "@/utils/color";
 const PANEL_W = 64;
 const PANEL_H = 64;
 const MAX_RECENT = 8;
+const DEFAULT_COLOR: Rgb = { r: 255, g: 138, b: 44 };
 
 /**
  * Paint mode produces the same shape as image mode (RGB888 row-major
- * bitmap). The driver renders both via Mode::Image — the only thing
- * that distinguishes paint is this composer. Reusing the parser so
- * legacy/upload-shaped configs still hydrate cleanly.
+ * bitmap) plus a persisted working `color`. The driver renders both
+ * via Mode::Image — the only thing that distinguishes paint is this
+ * composer. The persisted `color` (ignored by the renderer) lets the
+ * brush colour survive a reopen.
  */
-export { parseImageConfig as parsePaintConfig } from "./image";
+export type PaintSceneConfig = ImageSceneConfig & { color?: Rgb };
+
+function clamp255(n: unknown): number {
+  const v = typeof n === "number" ? n : 0;
+  return Math.max(0, Math.min(255, Math.round(v)));
+}
+
+/** Parse paint config: the image bitmap plus the sticky brush colour. */
+export function parsePaintConfig(raw: unknown): PaintSceneConfig {
+  const base = parseImageConfig(raw);
+  let color: Rgb | undefined;
+  if (raw && typeof raw === "object") {
+    const c = (raw as Record<string, unknown>).color;
+    if (c && typeof c === "object") {
+      const o = c as Record<string, unknown>;
+      color = { r: clamp255(o.r), g: clamp255(o.g), b: clamp255(o.b) };
+    }
+  }
+  return { ...base, color };
+}
 
 type Tool = "brush" | "fill" | "eraser" | "eyedrop";
 
@@ -30,31 +50,32 @@ export function PaintComposer({
   config,
 }: {
   panelId: string;
-  config: ImageSceneConfig;
+  config: PaintSceneConfig;
 }) {
   const [bitmap, setBitmap] = useState<Uint8ClampedArray>(
     () => bitmapFrom(config) ?? new Uint8ClampedArray(PANEL_W * PANEL_H * 4),
   );
 
-  // Snapshot of what we last persisted, so the sync-from-config
-  // effect below can ignore "the server told us back what we just
-  // pushed". Without it, our own writes would round-trip through
-  // realtime and clobber any in-flight stroke.
-  const lastPushedRef = useRef<string | null>(null);
-  // Sticky flag during a pointer-down stroke so an incoming server
+  // Snapshot (full byte copy) of what we last persisted, so the
+  // sync-from-config effect can ignore "the server told us back what
+  // we just pushed". A robust content comparison — the old fingerprint
+  // (length + first/last byte + rolling sum) collided easily, which
+  // could silently drop a real external update OR let a stale echo
+  // clobber a fresh local stroke.
+  const lastPushedRef = useRef<Uint8ClampedArray | null>(null);
+  // Sticky flag during a pointer/keyboard stroke so an incoming server
   // update doesn't yank the canvas out from under the user.
   const strokeInFlightRef = useRef(false);
 
   // External-update sync: when `config` changes (server pushed a
   // newer bitmap, e.g. another tab edited), refresh local state —
   // unless we're mid-stroke or the new payload is exactly what we
-  // just sent.
+  // just sent (compared byte-for-byte).
   useEffect(() => {
     const next = bitmapFrom(config);
     if (!next) return;
     if (strokeInFlightRef.current) return;
-    const fingerprint = configFingerprint(config);
-    if (fingerprint === lastPushedRef.current) return;
+    if (lastPushedRef.current && bytesEqual(next, lastPushedRef.current)) return;
     setBitmap(next);
   }, [config]);
 
@@ -71,33 +92,39 @@ export function PaintComposer({
   };
 
   const [tool, setTool] = useState<Tool>("brush");
-  const [color, setColor] = useState<Rgb>({ r: 255, g: 138, b: 44 });
+  // Sticky brush colour, hydrated from the persisted config so a
+  // reopen restores it.
+  const [color, setColor] = useState<Rgb>(config.color ?? DEFAULT_COLOR);
   const [grid, setGrid] = useState(true);
 
   // Per-instance recent-color list; cleared on panel switch.
   const [recentColors, setRecentColors] = useState<Rgb[]>([]);
-  const rememberColor = useCallback((c: Rgb) => {
+  const rememberColor = (c: Rgb) => {
     setRecentColors((prev) => {
       const filtered = prev.filter(
         (r) => !(r.r === c.r && r.g === c.g && r.b === c.b),
       );
       return [c, ...filtered].slice(0, MAX_RECENT);
     });
-  }, []);
+  };
 
-  const persist = useCallback(
-    (next: Uint8ClampedArray) => {
-      const arr = Array.from(next);
-      const config: ImageSceneConfig = {
-        width: PANEL_W,
-        height: PANEL_H,
-        bitmap: arr,
-      };
-      lastPushedRef.current = configFingerprint(config);
-      void panels.setMode.call(panelId, "paint", config);
-    },
-    [panelId],
-  );
+  // Persist a bitmap (+ the sticky brush colour) to mode_config. The
+  // colour rides along so reopening the editor restores it.
+  const persist = (next: Uint8ClampedArray, persistColor: Rgb) => {
+    const cfg: PaintSceneConfig = {
+      width: PANEL_W,
+      height: PANEL_H,
+      bitmap: Array.from(next),
+      color: persistColor,
+    };
+    // Store the exact bytes we're shipping for the echo guard.
+    lastPushedRef.current = new Uint8ClampedArray(next);
+    void panels.setMode.call(
+      panelId,
+      "paint",
+      cfg as unknown as Record<string, unknown>,
+    );
+  };
 
   const beginStroke = () => {
     strokeInFlightRef.current = true;
@@ -111,7 +138,7 @@ export function PaintComposer({
   const commit = (next: Uint8ClampedArray) => {
     strokeInFlightRef.current = false;
     setBitmap(next);
-    persist(next);
+    persist(next, color);
   };
 
   const handlePixel = (next: Uint8ClampedArray, x: number, y: number) => {
@@ -158,6 +185,22 @@ export function PaintComposer({
     commit(next);
   };
 
+  // Single-cell stroke (keyboard paint) — runs the full begin→step→
+  // commit cycle so it shares undo/persist with pointer strokes.
+  const paintCell = (x: number, y: number) => {
+    const working = beginStroke();
+    handlePixel(working, x, y);
+    commit(working);
+  };
+
+  // Set + persist the sticky brush colour (without touching the
+  // bitmap) so reopening the editor restores the last-used colour.
+  const changeColor = (next: Rgb) => {
+    setColor(next);
+    rememberColor(next);
+    persist(bitmap, next);
+  };
+
   return (
     <ComposerShell title="paint" status="64×64 pixel editor" ariaLabel="Paint configuration">
       <div className="space-y-4 px-4 py-4">
@@ -196,6 +239,7 @@ export function PaintComposer({
             setBitmap(new Uint8ClampedArray(working));
           }}
           onStrokeEnd={(working) => commit(working)}
+          onPaintCell={paintCell}
         />
 
         {/* Grid + recent colours */}
@@ -205,7 +249,7 @@ export function PaintComposer({
               type="checkbox"
               checked={grid}
               onChange={(e) => setGrid(e.target.checked)}
-              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus:ring-0 focus:ring-offset-0"
+              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)"
             />
             grid
           </label>
@@ -214,8 +258,8 @@ export function PaintComposer({
               <button
                 key={`${c.r}-${c.g}-${c.b}-${i}`}
                 type="button"
-                onClick={() => setColor(c)}
-                className="h-4 w-4 border border-(--color-border) hover:border-(--color-text)"
+                onClick={() => changeColor(c)}
+                className="h-4 w-4 border border-(--color-border) hover:border-(--color-text) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
                 style={{ background: `rgb(${c.r},${c.g},${c.b})` }}
                 aria-label={`Pick rgb(${c.r},${c.g},${c.b})`}
               />
@@ -225,21 +269,19 @@ export function PaintComposer({
 
         <div className="border-t border-dashed border-(--color-hairline)" />
 
-        <SolidColorPicker
-          value={color}
-          onChange={(next) => {
-            setColor(next);
-            rememberColor(next);
-          }}
-        />
+        <SolidColorPicker value={color} onChange={changeColor} />
       </div>
     </ComposerShell>
   );
 }
 
-/** Cheap content hash for skipping our own round-tripped writes. */
-function configFingerprint(config: ImageSceneConfig): string {
-  return `${config.width}x${config.height}:${config.bitmap.length}:${config.bitmap[0] ?? 0}:${config.bitmap[config.bitmap.length - 1] ?? 0}:${config.bitmap.reduce((a, b) => (a + b) | 0, 0)}`;
+/** True if two byte arrays are identical in length and content. */
+function bytesEqual(a: Uint8ClampedArray, b: Uint8ClampedArray): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 /* ─── canvas ──────────────────────────────────────────────────────── */
@@ -250,12 +292,14 @@ function PaintCanvas({
   onStrokeBegin,
   onStrokeStep,
   onStrokeEnd,
+  onPaintCell,
 }: {
   bitmap: Uint8ClampedArray;
   grid: boolean;
   onStrokeBegin: () => Uint8ClampedArray;
   onStrokeStep: (working: Uint8ClampedArray, x: number, y: number) => void;
   onStrokeEnd: (working: Uint8ClampedArray) => void;
+  onPaintCell: (x: number, y: number) => void;
 }) {
   // Fixed render size — keep it square and centered, rescale to fit
   // the available width via aspect-ratio + max-width on the wrapper.
@@ -263,8 +307,12 @@ function PaintCanvas({
   const workingRef = useRef<Uint8ClampedArray | null>(null);
   const lastCellRef = useRef<{ x: number; y: number } | null>(null);
 
-  // Repaint canvas whenever the bitmap changes. Cell size derived
-  // from the canvas's actual rendered width to stay crisp on resize.
+  // Keyboard cursor position. Arrows move it; Enter/Space paint the
+  // cell under it. Rendered as a highlighted outline so it's visible.
+  const [cursor, setCursor] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Repaint canvas whenever the bitmap (or cursor/grid) changes. Cell
+  // size derived from the canvas's actual rendered width to stay crisp.
   const repaint = useCallback(
     (canvas: HTMLCanvasElement, source: Uint8ClampedArray) => {
       const ctx = canvas.getContext("2d");
@@ -348,6 +396,7 @@ function PaintCanvas({
     workingRef.current = working;
     const { x, y } = cellAt(e);
     lastCellRef.current = { x, y };
+    setCursor({ x, y });
     onStrokeStep(working, x, y);
   };
 
@@ -375,8 +424,51 @@ function PaintCanvas({
     lastCellRef.current = null;
   };
 
+  // Keyboard model: arrows move the cursor (clamped to the grid),
+  // Enter/Space paint the cell under it. The wrapper is focusable.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case "ArrowLeft":
+        e.preventDefault();
+        setCursor((c) => ({ ...c, x: Math.max(0, c.x - 1) }));
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        setCursor((c) => ({ ...c, x: Math.min(PANEL_W - 1, c.x + 1) }));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setCursor((c) => ({ ...c, y: Math.max(0, c.y - 1) }));
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        setCursor((c) => ({ ...c, y: Math.min(PANEL_H - 1, c.y + 1) }));
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        onPaintCell(cursor.x, cursor.y);
+        break;
+    }
+  };
+
+  // Cursor outline as a CSS overlay so it doesn't fight the canvas's
+  // own repaint cycle. Position is a percentage of the grid.
+  const cursorStyle: React.CSSProperties = {
+    left: `${(cursor.x / PANEL_W) * 100}%`,
+    top: `${(cursor.y / PANEL_H) * 100}%`,
+    width: `${(1 / PANEL_W) * 100}%`,
+    height: `${(1 / PANEL_H) * 100}%`,
+  };
+
   return (
-    <div className="mx-auto aspect-square w-full max-w-[384px] border border-(--color-border) bg-(--color-bg)">
+    <div
+      role="application"
+      aria-label="Paint canvas — arrow keys move the cursor, Enter or Space paints"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="relative mx-auto aspect-square w-full max-w-[384px] border border-(--color-border) bg-(--color-bg) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
+    >
       <canvas
         ref={canvasRef}
         onPointerDown={handleDown}
@@ -384,7 +476,12 @@ function PaintCanvas({
         onPointerUp={handleUp}
         onPointerCancel={handleUp}
         className="block h-full w-full touch-none cursor-crosshair"
-        aria-label="Paint canvas"
+        aria-hidden
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute border border-(--color-accent) shadow-[0_0_4px_var(--color-accent)]"
+        style={cursorStyle}
       />
     </div>
   );
@@ -406,19 +503,21 @@ function ToolGroup({
     { id: "eyedrop", glyph: "◉", label: "pick" },
   ];
   return (
-    <div className="flex items-center gap-px border border-(--color-border)">
+    <div role="radiogroup" aria-label="Tool" className="flex items-center gap-px border border-(--color-border)">
       {tools.map((t) => {
         const active = t.id === tool;
         return (
           <button
             key={t.id}
             type="button"
+            role="radio"
             onClick={() => onChange(t.id)}
             title={t.label}
             aria-label={t.label}
-            aria-pressed={active}
+            aria-checked={active}
             className={[
               "flex h-7 items-center gap-1.5 px-2 font-mono text-[10px] uppercase tracking-[0.25em] transition-colors",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
               active
                 ? "bg-(--color-accent)/15 text-(--color-accent)"
                 : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
@@ -453,6 +552,7 @@ function SmallButton({
       disabled={disabled}
       className={[
         "border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.25em] transition-colors disabled:cursor-not-allowed disabled:opacity-40",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
         variant === "danger"
           ? "border-(--color-danger)/40 text-(--color-danger)/80 hover:bg-(--color-danger)/10 hover:text-(--color-danger)"
           : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",

--- a/dash/src/app/scenes/shapes.tsx
+++ b/dash/src/app/scenes/shapes.tsx
@@ -2,14 +2,17 @@
 
 import {
   DEFAULT_SHAPES_CONFIG,
+  defaultShapesConfig,
+  oneOf,
+  SHAPE_KINDS,
   type ShapeKind,
   type ShapesSceneConfig,
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { Fader } from "@/app/components/Fader";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
-import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
-import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
+import { useComposerConfig } from "@/utils/useComposerConfig";
 
 const SHAPES: { id: ShapeKind; label: string; glyph: string; blurb: string }[] = [
   { id: "Cube", label: "cube", glyph: "▣", blurb: "8v · 12e" },
@@ -23,9 +26,9 @@ const SHAPES: { id: ShapeKind; label: string; glyph: string; blurb: string }[] =
 const SPEED_PRESETS = [0.25, 0.5, 1, 2, 4, 8];
 
 export function parseShapesConfig(raw: unknown): ShapesSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_SHAPES_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultShapesConfig();
   const obj = raw as Record<string, unknown>;
-  const kind = isShapeKind(obj.kind) ? obj.kind : DEFAULT_SHAPES_CONFIG.kind;
+  const kind = oneOf(obj.kind, SHAPE_KINDS, DEFAULT_SHAPES_CONFIG.kind);
   const colorRaw =
     obj.color && typeof obj.color === "object"
       ? (obj.color as Record<string, unknown>)
@@ -36,7 +39,7 @@ export function parseShapesConfig(raw: unknown): ShapesSceneConfig {
         g: clamp255(colorRaw.g),
         b: clamp255(colorRaw.b),
       }
-    : DEFAULT_SHAPES_CONFIG.color;
+    : { ...DEFAULT_SHAPES_CONFIG.color };
   const speed =
     typeof obj.speed === "number" && obj.speed > 0
       ? Math.max(0.05, Math.min(16, obj.speed))
@@ -47,17 +50,6 @@ export function parseShapesConfig(raw: unknown): ShapesSceneConfig {
       ? Math.max(0, Math.min(1, obj.opacity))
       : 0;
   return { kind, color, speed, depth_shade, opacity };
-}
-
-function isShapeKind(v: unknown): v is ShapeKind {
-  return (
-    v === "Cube" ||
-    v === "Tetrahedron" ||
-    v === "Octahedron" ||
-    v === "Icosahedron" ||
-    v === "Torus" ||
-    v === "Hypercube"
-  );
 }
 
 function clamp255(n: unknown): number {
@@ -77,20 +69,11 @@ export function ShapesComposer({
   panelId: string;
   config: ShapesSceneConfig;
 }) {
-  const [local, setLocal] = useSyncedFromProp(JSON.stringify(config), config);
-  const [pushDebounced] = useDebouncedSetMode<ShapesSceneConfig>(
+  const [draft, update] = useComposerConfig<ShapesSceneConfig>(
     panelId,
     "shapes",
+    config,
   );
-  const persist = (next: ShapesSceneConfig) => {
-    setLocal(next);
-    pushDebounced(next);
-  };
-
-  const speedPct =
-    ((local.speed - SPEED_PRESETS[0]) /
-      (SPEED_PRESETS[SPEED_PRESETS.length - 1] - SPEED_PRESETS[0])) *
-    100;
 
   return (
     <ComposerShell
@@ -104,18 +87,24 @@ export function ShapesComposer({
           <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
             :: shape
           </div>
-          <div className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-3">
+          <div
+            role="radiogroup"
+            aria-label="Shape"
+            className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-3"
+          >
             {SHAPES.map((s) => {
-              const active = s.id === local.kind;
+              const active = s.id === draft.kind;
               return (
                 <button
                   key={s.id}
                   type="button"
-                  onClick={() => persist({ ...local, kind: s.id })}
-                  aria-pressed={active}
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => update({ ...draft, kind: s.id })}
                   title={s.blurb}
                   className={[
                     "flex items-center gap-3 px-3 py-2.5 text-left transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
                     active
                       ? "bg-(--color-bg) text-(--color-accent)"
                       : "bg-(--color-surface)/70 text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
@@ -143,9 +132,9 @@ export function ShapesComposer({
                     </span>
                     <span
                       className={[
-                        "truncate font-mono text-[9px] tracking-wide",
+                        "truncate font-mono text-[10px] tracking-wide",
                         active
-                          ? "text-(--color-accent)/70"
+                          ? "text-(--color-accent)"
                           : "text-(--color-text-faint)",
                       ].join(" ")}
                     >
@@ -161,103 +150,35 @@ export function ShapesComposer({
         <div className="border-t border-dashed border-(--color-hairline)" />
 
         {/* Speed */}
-        <div className="space-y-2.5">
-          <div className="flex items-center justify-between">
-            <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-              {"// speed"}
-            </span>
-            <span
-              className="tabular-nums text-(--color-text)"
-              style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-            >
-              {local.speed.toFixed(2)}x
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              slow
-            </span>
-            <input
-              type="range"
-              min={SPEED_PRESETS[0]}
-              max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
-              step={0.05}
-              value={local.speed}
-              onChange={(e) =>
-                persist({ ...local, speed: Number(e.target.value) })
-              }
-              className="fader flex-1"
-              style={
-                { ["--fader-pos" as string]: `${speedPct}%` } as React.CSSProperties
-              }
-              aria-label="Rotation speed"
-            />
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              fast
-            </span>
-          </div>
-          <div className="flex flex-wrap items-center gap-1">
-            {SPEED_PRESETS.map((p) => {
-              const active = Math.abs(local.speed - p) < 0.01;
-              return (
-                <button
-                  key={p}
-                  type="button"
-                  onClick={() => persist({ ...local, speed: p })}
-                  className={[
-                    "border px-2 py-1 font-mono text-[9px] uppercase tracking-[0.25em] transition-colors",
-                    active
-                      ? "border-(--color-accent) bg-(--color-accent)/15 text-(--color-accent)"
-                      : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",
-                  ].join(" ")}
-                >
-                  {p}x
-                </button>
-              );
-            })}
-          </div>
-        </div>
+        <Fader
+          label="// speed"
+          value={draft.speed}
+          min={SPEED_PRESETS[0]}
+          max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
+          step={0.05}
+          onChange={(speed) => update({ ...draft, speed })}
+          format={(v) => `${v.toFixed(2)}x`}
+          endpoints={["slow", "fast"]}
+          presets={SPEED_PRESETS}
+          presetLabel={(v) => `${v}x`}
+          ariaLabel="Rotation speed"
+        />
 
         <div className="border-t border-dashed border-(--color-hairline)" />
 
         {/* Face opacity — 0 = wireframe-only, 1 = fully filled. Edges
          * are always drawn on top at full brightness regardless. */}
-        <div className="space-y-2.5">
-          <div className="flex items-center justify-between">
-            <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-              {"// face opacity"}
-            </span>
-            <span
-              className="tabular-nums text-(--color-text)"
-              style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-            >
-              {Math.round(local.opacity * 100)}%
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              wire
-            </span>
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.02}
-              value={local.opacity}
-              onChange={(e) =>
-                persist({ ...local, opacity: Number(e.target.value) })
-              }
-              className="fader flex-1"
-              style={
-                { ["--fader-pos" as string]: `${local.opacity * 100}%` } as React.CSSProperties
-              }
-              aria-label="Face opacity"
-            />
-            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              solid
-            </span>
-          </div>
-        </div>
+        <Fader
+          label="// face opacity"
+          value={draft.opacity}
+          min={0}
+          max={1}
+          step={0.02}
+          onChange={(opacity) => update({ ...draft, opacity })}
+          format={(v) => `${Math.round(v * 100)}%`}
+          endpoints={["wire", "solid"]}
+          ariaLabel="Face opacity"
+        />
 
         <label className="flex cursor-pointer items-center justify-between gap-3">
           <span className="flex flex-col gap-0.5">
@@ -270,11 +191,9 @@ export function ShapesComposer({
           </span>
           <input
             type="checkbox"
-            checked={local.depth_shade}
-            onChange={(e) =>
-              persist({ ...local, depth_shade: e.target.checked })
-            }
-            className="h-3.5 w-3.5 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus:ring-0 focus:ring-offset-0"
+            checked={draft.depth_shade}
+            onChange={(e) => update({ ...draft, depth_shade: e.target.checked })}
+            className="h-3.5 w-3.5 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)"
           />
         </label>
 
@@ -282,8 +201,8 @@ export function ShapesComposer({
 
         {/* Color */}
         <SolidColorPicker
-          value={local.color}
-          onChange={(next) => persist({ ...local, color: next })}
+          value={draft.color}
+          onChange={(color) => update({ ...draft, color })}
         />
       </div>
     </ComposerShell>

--- a/dash/src/app/scenes/test.tsx
+++ b/dash/src/app/scenes/test.tsx
@@ -2,13 +2,15 @@
 
 import {
   DEFAULT_TEST_CONFIG,
+  defaultTestConfig,
+  oneOf,
+  TEST_PATTERNS,
   type TestSceneConfig,
   type TestPatternId,
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
-import { panels } from "@/utils/actions";
-import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
+import { useComposerConfig } from "@/utils/useComposerConfig";
 
 const PATTERNS: { id: TestPatternId; label: string; blurb: string }[] = [
   { id: "ColorBars",    label: "color bars",    blurb: "RGB primaries + corner pixels for geometry" },
@@ -17,11 +19,10 @@ const PATTERNS: { id: TestPatternId; label: string; blurb: string }[] = [
 ];
 
 export function parseTestConfig(raw: unknown): TestSceneConfig {
-  if (!raw || typeof raw !== "object") return DEFAULT_TEST_CONFIG;
+  if (!raw || typeof raw !== "object") return defaultTestConfig();
   const obj = raw as Record<string, unknown>;
-  const valid = PATTERNS.some((p) => p.id === obj.pattern);
   return {
-    pattern: valid ? (obj.pattern as TestPatternId) : DEFAULT_TEST_CONFIG.pattern,
+    pattern: oneOf(obj.pattern, TEST_PATTERNS, DEFAULT_TEST_CONFIG.pattern),
   };
 }
 
@@ -32,12 +33,11 @@ export function TestComposer({
   panelId: string;
   config: TestSceneConfig;
 }) {
-  const [local, setLocal] = useSyncedFromProp(JSON.stringify(config), config);
-
-  const persist = (next: TestSceneConfig) => {
-    setLocal(next);
-    void panels.setMode.call(panelId, "test", next);
-  };
+  const [draft, update] = useComposerConfig<TestSceneConfig>(
+    panelId,
+    "test",
+    config,
+  );
 
   return (
     <ComposerShell title="test" status="diagnostic patterns" ariaLabel="Test pattern configuration">
@@ -46,16 +46,19 @@ export function TestComposer({
           static patterns for diagnosing dead pixels, geometry,
           PWM linearity, moiré.
         </p>
-        <div className="space-y-1">
+        <div role="radiogroup" aria-label="Test pattern" className="space-y-1">
           {PATTERNS.map((p) => {
-            const active = p.id === local.pattern;
+            const active = p.id === draft.pattern;
             return (
               <button
                 key={p.id}
                 type="button"
-                onClick={() => persist({ pattern: p.id })}
+                role="radio"
+                aria-checked={active}
+                onClick={() => update({ pattern: p.id })}
                 className={[
                   "flex w-full items-baseline justify-between gap-3 border px-3 py-2 text-left transition",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
                   active
                     ? "border-(--color-accent) bg-(--color-accent)/10"
                     : "border-(--color-border) hover:border-(--color-border-strong) hover:bg-(--color-surface-2)",

--- a/dash/src/app/scenes/types.ts
+++ b/dash/src/app/scenes/types.ts
@@ -8,6 +8,20 @@
 import type { PanelMode } from "@/utils/actions";
 
 /**
+ * Validate a raw value against a closed set of allowed literals,
+ * falling back to `fallback` when it's not a member. Collapses the
+ * repeated "is this one of N enum strings, else default" pattern the
+ * scene parsers each re-implemented by hand.
+ */
+export function oneOf<T extends string>(
+  raw: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return (allowed as readonly unknown[]).includes(raw) ? (raw as T) : fallback;
+}
+
+/**
  * Tagged union describing the contents of `display_core::Mode`.
  * Externally-tagged so JSON looks like `{ "Text": {...} }`.
  */
@@ -79,6 +93,13 @@ export const DEFAULT_CLOCK_CONFIG: ClockSceneConfig = {
   color: { r: 0xff, g: 0x8a, b: 0x2c },
 };
 
+/** Fresh copy of the clock defaults (incl. a new `color` object) — a
+ * shared mutable singleton would let one panel's edits leak into the
+ * next parse fall-through. */
+export function defaultClockConfig(): ClockSceneConfig {
+  return { ...DEFAULT_CLOCK_CONFIG, color: { ...DEFAULT_CLOCK_CONFIG.color } };
+}
+
 /**
  * Game of Life. Both the dash (in TS) and the driver (in Rust) tick
  * an independent simulation locally; the dash ships its current cell
@@ -113,11 +134,18 @@ export const DEFAULT_LIFE_CONFIG: LifeSceneConfig = {
   step_interval_frames: 8,
 };
 
+/** Fresh copy of the life defaults — see `defaultClockConfig`. */
+export function defaultLifeConfig(): LifeSceneConfig {
+  return { ...DEFAULT_LIFE_CONFIG, color: { ...DEFAULT_LIFE_CONFIG.color } };
+}
+
 /**
  * Static image frame. The dash downsamples uploads/URLs to fit the
- * panel and stores raw RGB888 row-major bytes. Black pixels are
- * treated as transparent on the panel side (matches the gif
- * decoder's transparent-pixel convention).
+ * panel and stores raw RGBA row-major bytes (4-byte stride; length is
+ * exactly `4 * width * height`). Alpha is binary on the panel side:
+ * `0` = leave the pixel unset, anything else = render at full
+ * intensity (the matrix has no partial transparency). Mirrors
+ * `display_core::frames::image::ImageScene`.
  */
 export type ImageScene = {
   width: number;
@@ -130,17 +158,23 @@ export type ImageSceneConfig = ImageScene & {
   source?: string;
 };
 
-export const DEFAULT_IMAGE_CONFIG: ImageSceneConfig = {
-  width: 0,
-  height: 0,
-  bitmap: [],
-};
+/**
+ * Returns a fresh copy each call — callers store this directly into
+ * mode_config state, so a shared mutable singleton would let one
+ * panel's edits leak into the next fall-through default.
+ */
+export function defaultImageConfig(): ImageSceneConfig {
+  return { width: 0, height: 0, bitmap: [] };
+}
 
 /**
  * Animated GIF. The dash decodes the gif, downsamples each frame to
- * fit the panel, resolves disposal, and stores the resulting RGB888
- * frames + per-frame delays in mode_config. The driver steps through
- * the sequence based on accumulated step time.
+ * fit the panel, resolves disposal, and stores the resulting RGBA
+ * frames (4-byte stride; length is exactly `4 * width * height`) +
+ * per-frame delays in mode_config. Alpha is binary on the panel side
+ * (`0` = transparent, e.g. disposal masks; anything else = full
+ * intensity). The driver steps through the sequence based on
+ * accumulated step time. Mirrors `display_core::frames::gif`.
  */
 export type GifFrame = {
   bitmap: number[];
@@ -165,12 +199,13 @@ export type GifSceneConfig = GifScene & {
   source_frame_count?: number;
 };
 
-export const DEFAULT_GIF_CONFIG: GifSceneConfig = {
-  width: 0,
-  height: 0,
-  frames: [],
-  speed: 1,
-};
+/**
+ * Returns a fresh copy each call (incl. a new `frames` array) — see
+ * `defaultImageConfig` for why a shared mutable singleton is unsafe.
+ */
+export function defaultGifConfig(): GifSceneConfig {
+  return { width: 0, height: 0, frames: [], speed: 1 };
+}
 
 /**
  * Rotating 3-D wireframe. Picks a shape from a small catalogue
@@ -218,6 +253,21 @@ export const DEFAULT_SHAPES_CONFIG: ShapesSceneConfig = {
   opacity: 0,
 };
 
+/** Fresh copy of the shapes defaults — see `defaultClockConfig`. */
+export function defaultShapesConfig(): ShapesSceneConfig {
+  return { ...DEFAULT_SHAPES_CONFIG, color: { ...DEFAULT_SHAPES_CONFIG.color } };
+}
+
+/** The closed set of valid shape kinds — drives parse validation. */
+export const SHAPE_KINDS: readonly ShapeKind[] = [
+  "Cube",
+  "Tetrahedron",
+  "Octahedron",
+  "Icosahedron",
+  "Torus",
+  "Hypercube",
+];
+
 /**
  * Test/diagnostic patterns. Render-only — no animation, no per-frame
  * state. Mirrors `display_core::test::TestPattern` + `TestScene`.
@@ -233,6 +283,18 @@ export type TestSceneConfig = TestScene;
 export const DEFAULT_TEST_CONFIG: TestSceneConfig = {
   pattern: "ColorBars",
 };
+
+/** Fresh copy of the test defaults — see `defaultClockConfig`. */
+export function defaultTestConfig(): TestSceneConfig {
+  return { ...DEFAULT_TEST_CONFIG };
+}
+
+/** The closed set of valid test pattern ids — drives parse validation. */
+export const TEST_PATTERNS: readonly TestPatternId[] = [
+  "ColorBars",
+  "Gradient",
+  "Checkerboard",
+];
 
 export type ModeMeta = {
   id: PanelMode;

--- a/dash/src/globals.css
+++ b/dash/src/globals.css
@@ -22,19 +22,42 @@
   --color-border: #26262f;
   --color-border-strong: #3a3a47;
 
+  /* Text ramp. Three muted tiers below `--color-text`, each tuned to
+   * clear WCAG AA (≥4.5:1) against the dark surfaces they actually sit
+   * on (bg #08080a → surface-3 #1d1d24) — the faint tier was a serious
+   * contrast failure (~1.6:1) before. Still cool-tinted and quiet, just
+   * legible: faint ≈4.5–5.4:1, dim ≈6–7:1, muted ≈8–9.7:1, so the
+   * hierarchy stays visible. */
   --color-text: #e6e6ea;
-  --color-text-muted: #8b8b96;
-  --color-text-dim: #5d5d68;
-  --color-text-faint: #3a3a44;
+  --color-text-muted: #b4b4bd;
+  --color-text-dim: #9a9aa3;
+  --color-text-faint: #84848d;
 
-  --color-accent: #ff8a2c;
+  /* Accent family, unified on oklch so the orange is one consistent
+   * hue across the flat fill, the brighter glow, and the soft fade.
+   * (Was split between an sRGB hex and an oklch glow.) */
+  --color-accent: oklch(72.5% 0.17 52);
   --color-accent-glow: oklch(78% 0.16 50);
-  --color-accent-fade: color-mix(in oklch, #ff8a2c 18%, transparent);
+  --color-accent-fade: color-mix(in oklch, var(--color-accent) 18%, transparent);
 
   --color-phosphor: #5dffa9;
   --color-phosphor-fade: color-mix(in oklch, #5dffa9 18%, transparent);
   --color-amber: #ffb84d;
   --color-danger: #ff4d6d;
+
+  /* Swatch palette — the color-picker rainbow/preset grid currently
+   * hardcodes these hexes inline. Hoisted here as tokens so the pickers
+   * can reference them later (next agent wires them up). The rose/sun
+   * stops deliberately reuse the danger/amber hues; the rest fill out a
+   * coherent spectrum. Ordered as a rainbow sweep. */
+  --color-swatch-rose: #ff4d6d; /* ≈ --color-danger */
+  --color-swatch-amber: #ff8a2c; /* ≈ --color-accent (LED orange) */
+  --color-swatch-sun: #ffe066; /* ≈ --color-amber, brighter */
+  --color-swatch-lime: #a6e22e;
+  --color-swatch-cyan: #4de0e0;
+  --color-swatch-azure: #4da3ff;
+  --color-swatch-violet: #a04dff;
+  --color-swatch-white: #ffffff;
 
   --shadow-glow:
     0 0 20px -2px var(--color-accent-fade),
@@ -108,7 +131,7 @@ body::before {
     ),
     radial-gradient(
       ellipse 40% 30% at 90% 100%,
-      color-mix(in oklch, #ff4d6d 12%, transparent),
+      color-mix(in oklch, var(--color-danger) 12%, transparent),
       transparent 70%
     );
 }
@@ -213,4 +236,29 @@ button:not(:disabled),
 button:disabled,
 [role="button"][aria-disabled="true"] {
   cursor: not-allowed;
+}
+
+/* Motion-sensitive users: neutralize every moving piece of the
+ * instrument chrome. Covers our custom keyframes (cursor blink,
+ * marching tape) and the Tailwind utilities we lean on (pulse / ping
+ * for the live lamps, plus any transition). The status indicators
+ * still read fine static — color + glyph + label carry the state, not
+ * the animation. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    animation-delay: 0ms !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* The "ping" ring expands to a faint halo; with the animation frozen
+   * at frame 0 it would sit as an opaque dot over the lamp. Drop it
+   * entirely so the solid lamp underneath stays clean. */
+  .animate-ping {
+    display: none !important;
+  }
 }

--- a/dash/src/utils/actions.ts
+++ b/dash/src/utils/actions.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
-import { useEffect, useState } from "react";
-import useSWR, { useSWRConfig } from "swr";
+import { useEffect, useId, useState } from "react";
+import useSWR, { mutate as globalMutate, useSWRConfig } from "swr";
 
 import { Database } from "@/types/supabase";
 
@@ -21,36 +21,50 @@ export type TextEntryItem = Omit<
   "data"
 > & { data: TextEntry };
 
-const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-);
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY — set them in dash/.env.local",
+  );
+}
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 const getPanel = async (id: string) => {
-  const { data, error } = await supabase
+  const { data } = await supabase
     .from("panels")
     .select("*")
     .eq("id", id)
     .maybeSingle()
     .throwOnError();
-  if (data === null || error) {
-    throw error;
+  if (data === null) {
+    throw new Error(`panel ${id} not found`);
   }
   return data;
 };
 
-const getEntries = async (panel_id: string) => {
-  const { data, error } = await supabase
+// A row's `data` JSON is untyped at the DB boundary. Narrow it to the
+// shape composers rely on, dropping rows that don't match so one bad
+// row can't crash the whole queue render.
+const isTextEntry = (data: unknown): data is TextEntry => {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return typeof d.text === "string" && typeof d.options === "object" && d.options !== null;
+};
+
+const getEntries = async (panel_id: string): Promise<TextEntryItem[]> => {
+  const { data } = await supabase
     .from("entries")
     .select("*")
     .eq("panel_id", panel_id)
     .order("order", { ascending: true })
     .throwOnError();
-  if (data === null || error) {
-    throw error;
-  }
-  return data as TextEntryItem[];
+  return (data ?? []).filter((row) => isTextEntry(row.data)) as TextEntryItem[];
 };
+
+type EntriesCache = { entries: TextEntryItem[] };
+const entriesKey = (panelId: string) => `/entries/${panelId}`;
 
 const updatePanelLastUpdated = async (panelId: string) => {
   await supabase
@@ -60,17 +74,25 @@ const updatePanelLastUpdated = async (panelId: string) => {
     .throwOnError();
 };
 
-// Realtime pushes invalidations to SWR, so the polling fallback only
-// exists to recover from a missed websocket message and can be loose.
-const FALLBACK_REFRESH_INTERVAL = 30_000;
+// Realtime pushes invalidations to SWR, so polling is only a fallback
+// for a missed websocket message. When the channel is live we poll
+// rarely (60s backstop); when it's connecting/down we poll tighter
+// (15s) to recover quickly. `realtimeLive` is updated by
+// `useRealtimeRevalidation`; the page re-renders on status change so
+// the factory re-reads the interval.
+let realtimeLive = false;
+const LIVE_REFRESH_INTERVAL = 60_000;
+const FALLBACK_REFRESH_INTERVAL = 15_000;
 
 const useSWRFactory = <Result>(
   key: string | null,
   func: () => Promise<Result>,
-  { refreshInterval = FALLBACK_REFRESH_INTERVAL }: { refreshInterval?: number } = {},
+  { refreshInterval }: { refreshInterval?: number } = {},
 ) =>
   useSWR(key, func, {
-    refreshInterval,
+    refreshInterval:
+      refreshInterval ??
+      (realtimeLive ? LIVE_REFRESH_INTERVAL : FALLBACK_REFRESH_INTERVAL),
   });
 
 export type RealtimeStatus = "connecting" | "live" | "down";
@@ -84,10 +106,15 @@ export type RealtimeStatus = "connecting" | "live" | "down";
 export const useRealtimeRevalidation = (): RealtimeStatus => {
   const { mutate } = useSWRConfig();
   const [status, setStatus] = useState<RealtimeStatus>("connecting");
+  // Unique per mount so a StrictMode double-invoke (or two consumers)
+  // can't have the second subscribe race the first's removeChannel
+  // onto the same channel name.
+  const channelId = useId();
 
   useEffect(() => {
+    realtimeLive = false;
     const channel = supabase
-      .channel("led-dash-realtime")
+      .channel(`led-dash-realtime-${channelId}`)
       .on(
         "postgres_changes",
         { event: "*", schema: "public", table: "panels" },
@@ -96,7 +123,12 @@ export const useRealtimeRevalidation = (): RealtimeStatus => {
           const id =
             (payload.new as { id?: string })?.id ??
             (payload.old as { id?: string })?.id;
-          if (id) mutate(`/entries/scroll/${id}`);
+          if (id) {
+            mutate(`/entries/scroll/${id}`);
+            // A cascade-deleted panel takes its entries with it; drop
+            // the stale per-panel entries cache too.
+            if (payload.eventType === "DELETE") mutate(entriesKey(id));
+          }
         },
       )
       .on(
@@ -110,16 +142,23 @@ export const useRealtimeRevalidation = (): RealtimeStatus => {
         },
       )
       .subscribe((s) => {
-        if (s === "SUBSCRIBED") setStatus("live");
-        else if (s === "CLOSED" || s === "CHANNEL_ERROR" || s === "TIMED_OUT")
+        if (s === "SUBSCRIBED") {
+          realtimeLive = true;
+          setStatus("live");
+        } else if (s === "CLOSED" || s === "CHANNEL_ERROR" || s === "TIMED_OUT") {
+          realtimeLive = false;
           setStatus("down");
-        else setStatus("connecting");
+        } else {
+          realtimeLive = false;
+          setStatus("connecting");
+        }
       });
 
     return () => {
+      realtimeLive = false;
       void supabase.removeChannel(channel);
     };
-  }, [mutate]);
+  }, [mutate, channelId]);
 
   return status;
 };
@@ -204,57 +243,117 @@ export const entries = {
       ),
   },
 
+  // All three mutations update the `/entries/${panelId}` SWR cache
+  // optimistically and roll back on error, so callers just `await`
+  // and surface a thrown error — no manual `mutate` needed. The
+  // updater performs the write then returns the authoritative list.
+
   add: {
     call: async (panelId: string, entry: TextEntry) => {
-      // Insert at the top of the list. The driver renders entries in
-      // ascending `order`, so the lowest order ends up at the top of
-      // the matrix. We pick min(existing) - 1, which is atomic (no
-      // shifting other rows) and self-heals when a reorder rewrites
-      // everyone to 0..N-1.
-      const existing = await getEntries(panelId);
-      const minOrder = existing.length > 0
-        ? Math.min(...existing.map((e) => e.order))
-        : 0;
-      await supabase
-        .from("entries")
-        .insert({ panel_id: panelId, data: entry, order: minOrder - 1 })
-        .throwOnError();
-      await updatePanelLastUpdated(panelId);
+      const key = entriesKey(panelId);
+      // The driver renders entries in ascending `order`; lowest order
+      // shows at the top. min(existing)-1 is atomic (no row shifting)
+      // and self-heals when a reorder rewrites everyone to 0..N-1.
+      const optimisticRow: TextEntryItem = {
+        id: `optimistic-${Date.now()}`,
+        panel_id: panelId,
+        created_at: new Date().toISOString(),
+        order: Number.NEGATIVE_INFINITY,
+        data: entry,
+      } as TextEntryItem;
+      await globalMutate(
+        key,
+        async (current?: EntriesCache): Promise<EntriesCache> => {
+          const existing = current?.entries ?? (await getEntries(panelId));
+          const minOrder = existing.length
+            ? Math.min(...existing.map((e) => e.order))
+            : 0;
+          await supabase
+            .from("entries")
+            .insert({ panel_id: panelId, data: entry, order: minOrder - 1 })
+            .throwOnError();
+          await updatePanelLastUpdated(panelId);
+          return { entries: await getEntries(panelId) };
+        },
+        {
+          optimisticData: (current?: EntriesCache): EntriesCache => ({
+            entries: [optimisticRow, ...(current?.entries ?? [])],
+          }),
+          rollbackOnError: true,
+          revalidate: false,
+        },
+      );
     },
   },
 
   delete: {
     call: async (panelId: string, entryId: string) => {
-      await supabase
-        .from("entries")
-        .delete()
-        .eq("id", entryId)
-        .eq("panel_id", panelId)
-        .throwOnError();
-      await updatePanelLastUpdated(panelId);
+      const key = entriesKey(panelId);
+      await globalMutate(
+        key,
+        async (current?: EntriesCache): Promise<EntriesCache> => {
+          await supabase
+            .from("entries")
+            .delete()
+            .eq("id", entryId)
+            .eq("panel_id", panelId)
+            .throwOnError();
+          await updatePanelLastUpdated(panelId);
+          const base = current?.entries ?? (await getEntries(panelId));
+          return { entries: base.filter((e) => e.id !== entryId) };
+        },
+        {
+          optimisticData: (current?: EntriesCache): EntriesCache => ({
+            entries: (current?.entries ?? []).filter((e) => e.id !== entryId),
+          }),
+          rollbackOnError: true,
+          revalidate: false,
+        },
+      );
     },
   },
 
   /**
-   * Replace the order of every entry on the panel with positions
-   * derived from `orderedIds`. Issued as parallel UPDATEs — the
-   * driver's poll re-pulls all entries on `last_updated` change so
-   * partial application during a race is self-healing on the next
-   * refresh cycle.
+   * Replace the order of every entry with positions derived from
+   * `orderedIds`. Parallel UPDATEs — the driver re-pulls all entries
+   * on `last_updated` change so a partial race self-heals next poll.
    */
   reorder: {
     call: async (panelId: string, orderedIds: string[]) => {
-      await Promise.all(
-        orderedIds.map((id, order) =>
-          supabase
-            .from("entries")
-            .update({ order })
-            .eq("id", id)
-            .eq("panel_id", panelId)
-            .throwOnError(),
-        ),
+      const key = entriesKey(panelId);
+      await globalMutate(
+        key,
+        async (current?: EntriesCache): Promise<EntriesCache> => {
+          await Promise.all(
+            orderedIds.map((id, order) =>
+              supabase
+                .from("entries")
+                .update({ order })
+                .eq("id", id)
+                .eq("panel_id", panelId)
+                .throwOnError(),
+            ),
+          );
+          await updatePanelLastUpdated(panelId);
+          void current;
+          return { entries: await getEntries(panelId) };
+        },
+        {
+          optimisticData: (current?: EntriesCache): EntriesCache => {
+            const byId = new Map((current?.entries ?? []).map((e) => [e.id, e]));
+            return {
+              entries: orderedIds
+                .map((id, order) => {
+                  const row = byId.get(id);
+                  return row ? { ...row, order } : null;
+                })
+                .filter((e): e is TextEntryItem => e !== null),
+            };
+          },
+          rollbackOnError: true,
+          revalidate: false,
+        },
       );
-      await updatePanelLastUpdated(panelId);
     },
   },
 

--- a/dash/src/utils/color.ts
+++ b/dash/src/utils/color.ts
@@ -2,9 +2,12 @@
 
 export type Rgb = { r: number; g: number; b: number };
 
+const clampChannel = (v: number): number =>
+  Math.max(0, Math.min(255, Math.round(v)));
+
 export const rgbToHex = ({ r, g, b }: Rgb): string =>
   `#${[r, g, b]
-    .map((v) => v.toString(16).padStart(2, "0").toUpperCase())
+    .map((v) => clampChannel(v).toString(16).padStart(2, "0").toUpperCase())
     .join("")}`;
 
 export function hexToRgb(hex: string): Rgb | null {

--- a/dash/src/utils/useComposerConfig.ts
+++ b/dash/src/utils/useComposerConfig.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
+import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
+import type { PanelMode } from "@/utils/actions";
+
+/**
+ * One hook for every mode editor: holds an editable local mirror of
+ * the panel's persisted `mode_config` and debounce-writes changes
+ * back to Supabase.
+ *
+ * The local mirror resets only when the *target* changes
+ * (`panelId:mode`) — NOT when the config value changes. Keying on the
+ * value (e.g. `JSON.stringify(config)`) was the old footgun: a server
+ * echo of the user's own edit produced a new key and snapped the form
+ * back mid-drag. Keying on identity means a realtime refresh of the
+ * same panel/mode leaves the in-progress edit alone.
+ *
+ * Returns `[draft, update, flush]`:
+ *  - `draft`   — current editable config
+ *  - `update`  — set the draft AND queue a debounced persist
+ *  - `flush`   — persist immediately (for commit-style events / blur)
+ */
+export function useComposerConfig<C>(
+  panelId: string,
+  mode: PanelMode,
+  initial: C,
+  delayMs = 250,
+): [C, (next: C) => void, () => void] {
+  const [draft, setDraft] = useSyncedFromProp<C>(`${panelId}:${mode}`, initial);
+  const [push, flush] = useDebouncedSetMode<C>(panelId, mode, delayMs);
+
+  const update = (next: C) => {
+    setDraft(next);
+    push(next);
+  };
+
+  return [draft, update, flush];
+}

--- a/dash/src/utils/useDebouncedSetMode.ts
+++ b/dash/src/utils/useDebouncedSetMode.ts
@@ -15,7 +15,16 @@ export function useDebouncedSetMode<C>(
   delayMs = 250,
 ): [(config: C) => void, () => void] {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingRef = useRef<C | null>(null);
+  // The pending config carries the panel/mode it was edited against,
+  // captured at push() time (an event handler, so reading the current
+  // values is fine). flush() then writes to THAT target — switching
+  // panels mid-debounce (or before the unmount flush) can't misdirect
+  // a queued write to the wrong panel, the old first-render-capture bug.
+  const pendingRef = useRef<{
+    config: C;
+    panelId: string;
+    mode: PanelMode;
+  } | null>(null);
 
   const flush = () => {
     if (timerRef.current != null) {
@@ -26,24 +35,24 @@ export function useDebouncedSetMode<C>(
     if (pending == null) return;
     pendingRef.current = null;
     void panels.setMode.call(
-      panelId,
-      mode,
-      pending as unknown as Record<string, unknown>,
+      pending.panelId,
+      pending.mode,
+      pending.config as unknown as Record<string, unknown>,
     );
   };
 
   const push = (config: C) => {
-    pendingRef.current = config;
+    pendingRef.current = { config, panelId, mode };
     if (timerRef.current != null) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(flush, delayMs);
   };
 
-  // Auto-flush on unmount.
+  // Auto-flush on unmount. flush() reads the captured target from the
+  // pending ref, so the empty dep list is correct — no stale closure.
   useEffect(() => {
     return () => {
       flush();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return [push, flush];

--- a/dash/src/utils/useNow.ts
+++ b/dash/src/utils/useNow.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import useSWR from "swr";
 
 /**
@@ -12,10 +13,13 @@ import useSWR from "swr";
  * at the same interval share a single timer + render trigger.
  */
 export function useNow(intervalMs: number): number {
-  const { data } = useSWR(
-    `__now/${intervalMs}`,
-    () => Date.now(),
-    { refreshInterval: intervalMs, dedupingInterval: 0 },
-  );
-  return data ?? Date.now();
+  // Lazy initial keeps `Date.now()` out of the render body (it runs
+  // once, in the initializer) and seeds SWR's fallback so the first
+  // paint has a real timestamp.
+  const [initialNow] = useState(() => Date.now());
+  const { data } = useSWR(`__now/${intervalMs}`, () => Date.now(), {
+    refreshInterval: intervalMs,
+    fallbackData: initialNow,
+  });
+  return data;
 }

--- a/dash/src/utils/useSyncedFromProp.ts
+++ b/dash/src/utils/useSyncedFromProp.ts
@@ -10,6 +10,12 @@ import { useState } from "react";
  *
  * The state-during-render reset is the React 19 idiom for this — it
  * deduplicates and skips the extra paint, no `useEffect` needed.
+ *
+ * IMPORTANT: `key` must be a STABLE identity (e.g. `panelId:mode`),
+ * never the serialized value being edited. Keying on the value means
+ * the server echoing back the user's own edit produces a new key and
+ * snaps the form mid-edit. Prefer `useComposerConfig`, which gets
+ * this right.
  */
 export function useSyncedFromProp<T>(key: string, initial: T): [T, (next: T) => void] {
   const [snapshotKey, setSnapshotKey] = useState(key);

--- a/dash/wasm-sim/Cargo.lock
+++ b/dash/wasm-sim/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sim"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "console_error_panic_hook",
  "display-core",

--- a/dash/wasm-sim/Cargo.toml
+++ b/dash/wasm-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sim"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 
 # Standalone workspace. wasm-sim is `exclude`d from the parent

--- a/dash/wasm-sim/pkg/package.json
+++ b/dash/wasm-sim/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wasm-sim",
   "type": "module",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "files": [
     "wasm_sim_bg.wasm",
     "wasm_sim.js",


### PR DESCRIPTION
A deep audit + cleanup of the dash frontend. Driven by four parallel code reviews + a headless Playwright/axe audit (multi-viewport screenshots, console-error capture, WCAG scan). Result: **0 console errors and 0 axe violations** at mobile/tablet/desktop, production build clean, `cargo test -p display-core` unaffected.

Backwards-compat was explicitly out of scope, so changes are substantial. Six logically-separated commits:

1. **`refactor: optimistic data layer + hardened composer hooks`** — `entries.add/delete/reorder` now do optimistic SWR updates with rollback; polling gated on realtime status; unique realtime channel per mount; env assertion + per-row validation. `useDebouncedSetMode` tags pending writes with their target panel (no more wrong-panel writes on a mid-debounce switch); new `useComposerConfig` keyed on stable `panelId:mode` (kills the "echo resets edit mid-drag" bug); `useNow` purity fix; `rgbToHex` clamp.

2. **`perf: rework MatrixPreview render loop + canvas a11y`** — glow sprites cached instead of ~245k gradient allocs/sec; loop idles when offline/paused/off/static; geometry+DPR in refs (survives resize/display-move); hot-path 720KB stringify replaced with a structural key; canvas context-loss recovery; `role="img"` + state label. Caught & fixed a scene-push race in visual QA (preview rendered empty if WASM imported after the first frame).

3. **`fix: accessibility + contrast + theme-token pass`** — contrast ramp now passes WCAG AA (was failing on 11–14 elements); non-color status cues; full ARIA tab pattern in PanelSwitcher + "legacy" driver-version state; reduced-motion guard; accent unified on oklch; swatch palette tokens.

4. **`refactor: shared composer kit + per-mode editor fixes`** — new `SegmentedToggle` + `Fader` primitives, all editors migrated to `useComposerConfig`; paint self-echo fixed (real byte comparison) + keyboard cursor + color persistence; color pickers preserve state across rgb/rainbow toggle + commit-on-blur; ModeSwitcher stops wiping config; gif disposal-3 fix + RGBA contract reconciled with the Rust consumer; fresh-copy config defaults.

5. **`fix: resilient compose/queue flow + error boundary`** — EntriesList renders from cache, commits reorder on drag-end, surfaces failures, two-step delete; page send is try/catch with transmit-failure UX; `error.tsx` boundary so a bad `mode_config` can't blank the dash.

6. **`chore: playwright/axe dev deps + bump to 1.1.4`**.

## Test plan
- [x] `bunx tsc --noEmit` clean; `bun run lint` clean (1 pre-existing config warning); `bun run build` clean
- [x] Headless audit (mobile 375 / tablet 768 / desktop 1440): 0 console errors, 0 axe WCAG2A/2AA violations
- [x] Visual smoke of every mode editor + the MatrixPreview live glow (rendered "HELLO" via a throwaway probe page, since all physical panels are offline right now)
- [ ] Confirm the live preview on a real online panel once hardware is back up

🤖 Generated with [Claude Code](https://claude.com/claude-code)