### PR TITLE
fix(justfile): correct arch/feature split for Pi 5 vs Zero W flashing

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,12 @@
 # Default target architecture for the LED matrix Pis (Pi Zero W = armv6 hardfp).
-# Override per-invocation: `just arch=aarch64-unknown-linux-musl build`.
+# Pi 5 builds set arch=aarch64-unknown-linux-musl (use the `*-pi5`
+# recipes, which do this for you).
 arch := "arm-unknown-linux-gnueabihf"
+
+# The RP1 PIO backend (`rpi5`) is 64-bit-only and only needed on the
+# Pi 5 image, so it's enabled automatically when targeting aarch64 and
+# left out of the armv6 Zero W build (where the crate wouldn't compile).
+features := if arch =~ "aarch64" { "--features rpi5" } else { "" }
 
 # Non-sensitive runtime config. Exported so scripts inherit them
 # without re-declaring; sensitive values live in secrets/*.sops.json
@@ -16,8 +22,10 @@ default:
 
 # Cross-compile the driver and the WiFi onboarding binary. Requires `cross`
 # (https://github.com/cross-rs/cross) and a running Docker daemon.
+# Builds the two deployed binaries explicitly (not `--workspace`) so the
+# armv6 build never pulls in the 64-bit-only `rp1-pio` crate.
 build:
-    cross build --workspace --target {{ arch }} --release
+    cross build -p led-driver -p led-wifi-setup --target {{ arch }} --release {{ features }}
 
 # Sanity: the workspace builds for the host arch (no cross involved).
 check:
@@ -49,15 +57,19 @@ deploy host user="root": build
         && systemctl restart led-driver.service \
         && rm /usr/local/bin/led-driver.new'
 
-# Build + deploy for a Raspberry Pi 5 (aarch64 + RP1 PIO backend). The
-# aarch64 image carries both backends (`rpi`,`rpi5`); the driver picks
-# RP1 vs BCM at runtime by detecting the board.
+# Pi 5 convenience wrappers. They re-invoke the matching recipe with
+# `arch=aarch64-unknown-linux-musl`, which (a) cross-builds the right
+# target, (b) auto-enables the `rpi5` RP1 PIO backend via `features`,
+# and (c) makes flash-sd.sh fetch the 64-bit Pi OS image. The aarch64
+# build carries both backends; the driver picks RP1 vs BCM at runtime.
+
+# Flash a fresh Pi 5 SD card (64-bit image + RP1 PIO backend).
+flash-sd-pi5 id host device color-order="RGB":
+    just arch=aarch64-unknown-linux-musl flash-sd "{{ id }}" "{{ host }}" "{{ device }}" "{{ color-order }}"
+
+# Build + deploy to a running Pi 5.
 deploy-pi5 host user="root":
-    cross build -p led-driver --target aarch64-unknown-linux-musl --release --features rpi5
-    scp target/aarch64-unknown-linux-musl/release/led-driver "{{ user }}@{{ host }}:/usr/local/bin/led-driver.new"
-    ssh "{{ user }}@{{ host }}" 'install -m 0755 /usr/local/bin/led-driver.new /usr/local/bin/led-driver \
-        && systemctl restart led-driver.service \
-        && rm /usr/local/bin/led-driver.new'
+    just arch=aarch64-unknown-linux-musl deploy "{{ host }}" "{{ user }}"
 
 # Tail the driver service journal on a host.
 logs host user="root":


### PR DESCRIPTION
Follow-up to the RP1 PIO backend (#34). Fixes two build/flash issues it surfaced.

## 1. Repairs the Zero W (armv6) build
`build` used `cross build --workspace`, which now compiles the new `rp1-pio` crate for every member — including the armv6 Zero W target. `rp1-pio`'s ioctl structs are 64-bit-only (their compile-time size asserts assume `void* = 8 bytes`), so they **fail to compile on 32-bit**, breaking the Zero W build. Fix: build the two deployed binaries explicitly (`-p led-driver -p led-wifi-setup`) so armv6 never pulls `rp1-pio`.

## 2. Makes Pi 5 flashing actually 64-bit + RP1
`ARCH=… just flash-sd` silently produced a 32-bit armhf card — the env var doesn't override just's internal `arch` variable, so the build target, the baked binary, and the downloaded Pi OS image all stayed armhf (this is why the first Pi 5 card came out 32-bit and we hand-swapped a static binary). Fix:
- a `features` variable derived from `arch` that auto-enables `rpi5` on aarch64,
- `flash-sd-pi5` / `deploy-pi5` convenience recipes that re-invoke with `arch=aarch64-unknown-linux-musl`.

So one knob — `arch` — now drives the cross target, the RP1 feature, and the Pi OS image together. `just flash-sd-pi5 home led-alpha /dev/sda` yields a correct 64-bit image with the RP1 backend baked in, no manual swap.

## Test plan
- [x] `just -n build` (armv6) → `cross build -p led-driver -p led-wifi-setup --target arm-unknown-linux-gnueabihf --release` (no rpi5)
- [x] `just -n arch=aarch64-unknown-linux-musl build` → adds `--features rpi5`
- [x] dep tree: armv6 default has **0** `rp1-pio` refs; aarch64+rpi5 has it
- [x] `flash-sd-pi5` / `deploy-pi5` dry-runs recurse with the aarch64 arch

🤖 Generated with [Claude Code](https://claude.com/claude-code)