### PR TITLE
fix(wifi-setup): join WPA3-Personal (SAE) and open networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -1086,7 +1086,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "led-driver"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "led-wifi-setup"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "rp1-pio"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/display-core", "crates/driver", "crates/rp1-pio", "crates/wif
 # = true` picks it up. Internal-fleet system; we ship as a unit, so
 # per-crate semver doesn't carry information for us.
 [workspace.package]
-version = "1.1.9"
+version = "1.1.10"
 # wasm-sim has its own [profile.release] (opt-level = "z", lto, single
 # codegen unit — wasm-pack defaults) that would conflict with the
 # workspace's release profile, so keep it out and build it via

--- a/crates/wifi-setup/src/main.rs
+++ b/crates/wifi-setup/src/main.rs
@@ -192,8 +192,13 @@ struct ConnectForm {
 
 /// How to authenticate to the chosen network.
 enum NetworkAuth {
-    /// WPA/WPA2/WPA3-Personal pre-shared key.
-    Personal { psk: String },
+    /// Open network — no security.
+    Open,
+    /// Personal password. `sae` selects WPA3 (key-mgmt `sae`) vs WPA2
+    /// (`wpa-psk`); deriving this from the scanned security is what lets
+    /// a WPA3-Personal network join — forcing `wpa-psk` makes a
+    /// WPA3/SAE AP reject every BSS (ssid-not-found).
+    Psk { psk: String, sae: bool },
     /// WPA/WPA2/WPA3-Enterprise (802.1X) with a username + password.
     /// `eap` is `peap`|`ttls`; `phase2` is the inner auth
     /// (`mschapv2`|`pap`). The server cert is not validated (no
@@ -206,6 +211,32 @@ enum NetworkAuth {
         password: String,
         anonymous: Option<String>,
     },
+}
+
+impl NetworkAuth {
+    /// Short label for logs.
+    fn kind(&self) -> &'static str {
+        match self {
+            NetworkAuth::Open => "open",
+            NetworkAuth::Psk { sae: true, .. } => "psk-wpa3",
+            NetworkAuth::Psk { sae: false, .. } => "psk-wpa2",
+            NetworkAuth::Enterprise { .. } => "enterprise",
+        }
+    }
+}
+
+/// Personal key-management for a network given its scanned SECURITY
+/// string (nmcli's `WPA2` / `WPA3` / `WPA2 WPA3` / `802.1X` / empty).
+/// `None` when the network is open (caller maps that to no password).
+fn psk_uses_sae(security: &str) -> bool {
+    // A WPA3 (or WPA2/WPA3 transition) network supports SAE; pick it.
+    // Pure WPA2/WPA1 uses WPA-PSK.
+    security.to_ascii_uppercase().contains("WPA3")
+}
+
+fn is_open_security(security: &str) -> bool {
+    let s = security.trim().to_ascii_uppercase();
+    s.is_empty() || s == "--"
 }
 
 async fn captive_redirect() -> Redirect {
@@ -363,6 +394,16 @@ async fn connect_handler(
             Html(error_page(msg)),
         )
     };
+    // The scanned security for the chosen SSID decides WPA2 vs WPA3 vs
+    // open on the personal path. `None` = not in the scan (a manually-
+    // typed/hidden SSID), which we treat as secured-unknown (require a
+    // password, default WPA-PSK) rather than open.
+    let scanned_security = state
+        .networks
+        .iter()
+        .find(|n| n.ssid == ssid)
+        .map(|n| n.security.clone());
+
     let auth = if form.mode == "enterprise" {
         let identity = form.identity.trim().to_string();
         let password = form.password;
@@ -380,13 +421,25 @@ async fn connect_handler(
             }
         };
         NetworkAuth::Enterprise { eap, phase2, identity, password, anonymous }
+    } else if matches!(&scanned_security, Some(s) if is_open_security(s)) {
+        // Scanned and genuinely open — no password needed.
+        NetworkAuth::Open
     } else {
         if form.psk.is_empty() {
             return bad("Enter the network password.");
         }
-        NetworkAuth::Personal { psk: form.psk }
+        // WPA3 → SAE; WPA2/unknown → WPA-PSK.
+        let sae = scanned_security
+            .as_deref()
+            .is_some_and(psk_uses_sae);
+        NetworkAuth::Psk { psk: form.psk, sae }
     };
-    tracing::info!(%ssid, enterprise = matches!(auth, NetworkAuth::Enterprise { .. }), "applying network");
+    tracing::info!(
+        %ssid,
+        security = scanned_security.as_deref().unwrap_or("(unscanned)"),
+        kind = auth.kind(),
+        "applying network"
+    );
 
     let result = apply_network(&ssid, &auth).await;
     match result {
@@ -463,8 +516,16 @@ async fn apply_network(ssid: &str, auth: &NetworkAuth) -> Result<()> {
         args.push(v.to_string());
     };
     match auth {
-        NetworkAuth::Personal { psk } => {
-            push("wifi-sec.key-mgmt", "wpa-psk");
+        NetworkAuth::Open => {
+            // No security block — see `bring_up_ap` for why key-mgmt
+            // none is avoided.
+        }
+        NetworkAuth::Psk { psk, sae } => {
+            // SAE = WPA3-Personal (the password goes in the same
+            // wifi-sec.psk field; NM negotiates the mandatory PMF).
+            // wpa-psk = WPA/WPA2. Forcing wpa-psk on a WPA3 network was
+            // the bug that produced ssid-not-found.
+            push("wifi-sec.key-mgmt", if *sae { "sae" } else { "wpa-psk" });
             push("wifi-sec.psk", psk);
         }
         NetworkAuth::Enterprise {
@@ -751,4 +812,30 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#x27;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wpa3_networks_use_sae() {
+        // WPA3-only and WPA2/WPA3 transition both support SAE.
+        assert!(psk_uses_sae("WPA3"));
+        assert!(psk_uses_sae("WPA2 WPA3"));
+        assert!(psk_uses_sae("wpa3"));
+        // Pure WPA2/WPA1 do not.
+        assert!(!psk_uses_sae("WPA2"));
+        assert!(!psk_uses_sae("WPA1 WPA2"));
+        assert!(!psk_uses_sae(""));
+    }
+
+    #[test]
+    fn open_security_detection() {
+        assert!(is_open_security(""));
+        assert!(is_open_security("  "));
+        assert!(is_open_security("--"));
+        assert!(!is_open_security("WPA2"));
+        assert!(!is_open_security("WPA3"));
+    }
 }

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "led-dash",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "packageManager": "bun@1.2.20",
   "scripts": {

--- a/dash/wasm-sim/Cargo.lock
+++ b/dash/wasm-sim/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sim"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "console_error_panic_hook",
  "display-core",

--- a/dash/wasm-sim/Cargo.toml
+++ b/dash/wasm-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sim"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2021"
 
 # Standalone workspace. wasm-sim is `exclude`d from the parent

--- a/dash/wasm-sim/pkg/package.json
+++ b/dash/wasm-sim/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wasm-sim",
   "type": "module",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "files": [
     "wasm_sim_bg.wasm",
     "wasm_sim.js",


### PR DESCRIPTION
## Why
Diagnosed from the office panel's SD card: it failed to join the guest network **"A Visitor"** three times, each with NetworkManager reason `ssid-not-found` ("association took too long"). The radio saw the network in the scan but found **no matching BSS** at connect time. Root cause: "A Visitor" is **WPA3-Personal (SAE)**, but the onboarding hard-coded `wifi-sec.key-mgmt=wpa-psk` (WPA2-only). A WPA3/SAE AP rejects WPA-PSK association entirely → no suitable BSS → `ssid-not-found`.

(The `NeuralNet`/enterprise angle was a red herring — that was a one-off test submitted in Personal mode. The real target was the WPA3 PSK guest network.)

## Fix
Derive the key management from the chosen network's **scanned SECURITY** instead of forcing `wpa-psk`:
- contains `WPA3` (incl. WPA2/WPA3 transition) → `key-mgmt sae`
- `WPA1`/`WPA2` → `key-mgmt wpa-psk`
- empty (scanned, genuinely open) → no security block, no password required (new `NetworkAuth::Open`)
- not in scan (manual/hidden SSID) → treated as secured WPA-PSK (require a password), not open

SAE uses the same `wifi-sec.psk` field for the passphrase; NM negotiates the mandatory PMF. Adds unit tests for the derivation.

## Test plan
- [x] `cargo build`/`clippy`/unit tests pass (host + aarch64 cross)
- [x] lockstep bump 1.1.9 → 1.1.10
- [x] New aarch64 wifi-setup binary installed onto the office card + the broken WPA2-PSK `led-wifi` connection cleared, so it re-enters setup cleanly
- [ ] On-device: boot at the office, pick "A Visitor", enter the password → joins via SAE (user-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)