### PR TITLE
fix(wifi-setup): WPA3-SAE hash-to-element (H2E) for onboard Broadcom wifi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -1086,7 +1086,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "led-driver"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "led-wifi-setup"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "rp1-pio"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/display-core", "crates/driver", "crates/rp1-pio", "crates/wif
 # = true` picks it up. Internal-fleet system; we ship as a unit, so
 # per-crate semver doesn't carry information for us.
 [workspace.package]
-version = "1.1.10"
+version = "1.1.11"
 # wasm-sim has its own [profile.release] (opt-level = "z", lto, single
 # codegen unit — wasm-pack defaults) that would conflict with the
 # workspace's release profile, so keep it out and build it via

--- a/crates/wifi-setup/src/main.rs
+++ b/crates/wifi-setup/src/main.rs
@@ -557,6 +557,18 @@ async fn apply_network(ssid: &str, auth: &NetworkAuth) -> Result<()> {
 
     nmcli(args).await.context("nmcli connection add")?;
 
+    // WPA3-SAE: force hash-to-element (H2E) on the supplicant before we
+    // bring the connection up. The onboard Broadcom firmware only does
+    // legacy hunt-and-peck SAE, which WiFi-6 / enterprise WPA3 APs reject
+    // with status_code=16; sae_pwe=2 offers both methods. NetworkManager
+    // exposes no property for this, so we poke the running supplicant
+    // directly. The led-sae-h2e.service oneshot does the same at every
+    // boot to keep it set across reboots; this call makes a *fresh*
+    // portal onboarding work without waiting on that timing.
+    if matches!(auth, NetworkAuth::Psk { sae: true, .. }) {
+        set_sae_h2e().await;
+    }
+
     nmcli(["connection", "up", "led-wifi"])
         .await
         .context("nmcli connection up")?;
@@ -774,6 +786,25 @@ where
         return Err(anyhow!("nmcli failed: {}", stderr.trim()));
     }
     Ok(())
+}
+
+/// Enable WPA3-SAE hash-to-element (`sae_pwe=2`) on the running
+/// wpa_supplicant. Best-effort: a failure just leaves the supplicant on
+/// its hunt-and-peck default, so non-H2E WPA3 networks still work. See
+/// `service/led-sae-h2e.sh` for the full rationale.
+async fn set_sae_h2e() {
+    match Command::new("wpa_cli")
+        .args(["-i", "wlan0", "set", "sae_pwe", "2"])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => tracing::info!("set sae_pwe=2 (WPA3 H2E)"),
+        Ok(out) => tracing::warn!(
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "wpa_cli set sae_pwe failed",
+        ),
+        Err(err) => tracing::warn!(%err, "could not spawn wpa_cli to set sae_pwe"),
+    }
 }
 
 async fn nmcli_value<I, S>(args: I) -> Result<String>

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "led-dash",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "packageManager": "bun@1.2.20",
   "scripts": {

--- a/dash/wasm-sim/Cargo.lock
+++ b/dash/wasm-sim/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sim"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "console_error_panic_hook",
  "display-core",

--- a/dash/wasm-sim/Cargo.toml
+++ b/dash/wasm-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sim"
-version = "1.1.10"
+version = "1.1.11"
 edition = "2021"
 
 # Standalone workspace. wasm-sim is `exclude`d from the parent

--- a/dash/wasm-sim/pkg/package.json
+++ b/dash/wasm-sim/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wasm-sim",
   "type": "module",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "files": [
     "wasm_sim_bg.wasm",
     "wasm_sim.js",

--- a/scripts/flash-sd.sh
+++ b/scripts/flash-sd.sh
@@ -137,9 +137,11 @@ sudo install -D -m 0644 "$cfg_tmp"                                   "$root_mnt/
 sudo install -D -m 0755 "target/$ARCH/release/led-driver"             "$root_mnt/usr/local/bin/led-driver"
 sudo install -D -m 0755 "target/$ARCH/release/led-wifi-setup"         "$root_mnt/usr/local/bin/led-wifi-setup"
 sudo install -D -m 0755 service/led-tailscale-init                    "$root_mnt/usr/local/bin/led-tailscale-init"
+sudo install -D -m 0755 service/led-sae-h2e.sh                        "$root_mnt/usr/local/bin/led-sae-h2e.sh"
 sudo install -D -m 0644 service/led-driver.service                    "$root_mnt/etc/systemd/system/led-driver.service"
 sudo install -D -m 0644 service/led-wifi-setup.service                "$root_mnt/etc/systemd/system/led-wifi-setup.service"
 sudo install -D -m 0644 service/led-tailscale-init.service            "$root_mnt/etc/systemd/system/led-tailscale-init.service"
+sudo install -D -m 0644 service/led-sae-h2e.service                   "$root_mnt/etc/systemd/system/led-sae-h2e.service"
 sudo install -D -m 0644 service/alsa-blacklist.conf                   "$root_mnt/etc/modprobe.d/led-alsa-blacklist.conf"
 sudo install -D -m 0644 service/captive-dnsmasq.conf                  "$root_mnt/etc/NetworkManager/dnsmasq-shared.d/captive-portal.conf"
 sudo install -D -m 0644 service/disable-ipv6.conf                     "$root_mnt/etc/sysctl.d/99-led-disable-ipv6.conf"
@@ -190,7 +192,7 @@ trap cleanup EXIT
 # follow where each unit's source lives: ours under /etc/systemd/system,
 # systemd-shipped under /lib/systemd/system.
 sudo install -d -m 0755 "$root_mnt/etc/systemd/system/multi-user.target.wants"
-for unit in led-driver.service led-wifi-setup.service led-tailscale-init.service; do
+for unit in led-driver.service led-wifi-setup.service led-tailscale-init.service led-sae-h2e.service; do
     sudo ln -sf "/etc/systemd/system/$unit" \
         "$root_mnt/etc/systemd/system/multi-user.target.wants/$unit"
 done

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -66,10 +66,12 @@ ssh "$USER@$HOST" '
 scp service/led-driver.service          "$USER@$HOST:/etc/systemd/system/led-driver.service"
 scp service/led-wifi-setup.service      "$USER@$HOST:/etc/systemd/system/led-wifi-setup.service"
 scp service/led-tailscale-init.service  "$USER@$HOST:/etc/systemd/system/led-tailscale-init.service"
-# led-tailscale-init is a shell script, not a running ELF — scp
-# directly to canonical path; no atomic-rename dance needed. Mode
-# fixup happens in the install ssh block below to save a round-trip.
+scp service/led-sae-h2e.service         "$USER@$HOST:/etc/systemd/system/led-sae-h2e.service"
+# led-tailscale-init and led-sae-h2e.sh are shell scripts, not running
+# ELFs — scp directly to canonical path; no atomic-rename dance needed.
+# Mode fixup happens in the install ssh block below to save a round-trip.
 scp service/led-tailscale-init          "$USER@$HOST:/usr/local/bin/led-tailscale-init"
+scp service/led-sae-h2e.sh              "$USER@$HOST:/usr/local/bin/led-sae-h2e.sh"
 
 # Binaries. scp can't overwrite the running ELF, so we ship as `.new`
 # and atomic-rename. `install` preserves perms and hands the running
@@ -85,10 +87,10 @@ scp "$driver_bin"  "$USER@$HOST:/usr/local/bin/led-driver.new"
 scp "$wifi_bin"    "$USER@$HOST:/usr/local/bin/led-wifi-setup.new"
 ssh "$USER@$HOST" 'install -m 0755 /usr/local/bin/led-driver.new     /usr/local/bin/led-driver \
     && install -m 0755 /usr/local/bin/led-wifi-setup.new /usr/local/bin/led-wifi-setup \
-    && chmod 0755 /usr/local/bin/led-tailscale-init \
+    && chmod 0755 /usr/local/bin/led-tailscale-init /usr/local/bin/led-sae-h2e.sh \
     && rm /usr/local/bin/led-driver.new /usr/local/bin/led-wifi-setup.new \
     && systemctl daemon-reload \
-    && systemctl enable led-driver.service led-wifi-setup.service led-tailscale-init.service \
+    && systemctl enable led-driver.service led-wifi-setup.service led-tailscale-init.service led-sae-h2e.service \
     && systemctl restart led-driver.service led-wifi-setup.service'
 echo "==> initialized $HOST (id=$PANEL_ID); led-driver + led-wifi-setup restarted with new binaries."
 echo "    led-tailscale-init takes effect on the next boot (no in-place restart needed)."

--- a/service/led-sae-h2e.service
+++ b/service/led-sae-h2e.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Force WPA3-SAE hash-to-element (H2E) on onboard Broadcom wifi
+Documentation=https://github.com/ziyadedher/led
+# wlan0 only exists in the supplicant once NM brings the radio up, so we
+# order after both and let the script poll for the interface.
+After=wpa_supplicant.service NetworkManager.service
+Wants=wpa_supplicant.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/led-sae-h2e.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/service/led-sae-h2e.sh
+++ b/service/led-sae-h2e.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Force WPA3-SAE hash-to-element (H2E) on the onboard wifi.
+#
+# The Broadcom brcmfmac firmware (BCM43455 on Pi Zero W / Pi 4 / Pi 5)
+# offloads SAE to firmware, which only does the legacy hunting-and-pecking
+# PWE method. WiFi-6 / enterprise WPA3 APs commonly *require* the newer
+# hash-to-element method and reject hunt-and-peck association with
+# status_code=16 ("timeout waiting for next frame in sequence").
+#
+# NetworkManager drives wpa_supplicant over D-Bus with no global config
+# file, and NM 1.52 doesn't expose the `sae-pwe` per-connection property,
+# so there's no declarative way to set it. wpa_supplicant in D-Bus mode
+# also doesn't apply `sae_pwe` from a `-c` global config to interfaces NM
+# registers. The one thing that works is setting it at runtime on the live
+# interface: `wpa_cli set sae_pwe 2` (2 = offer both H2E and hunt-peck).
+#
+# This oneshot waits for wlan0 to appear in the supplicant, sets sae_pwe=2,
+# then nudges the stored connection up so a WPA3 network that failed its
+# first (pre-H2E) autoconnect attempt re-associates. Harmless on open /
+# WPA2 / non-WPA3 networks.
+for _ in $(seq 1 90); do
+    if wpa_cli -i wlan0 set sae_pwe 2 >/dev/null 2>&1; then
+        nmcli connection up led-wifi >/dev/null 2>&1 || true
+        exit 0
+    fi
+    sleep 1
+done
+exit 0


### PR DESCRIPTION
## What

The office guest network ("A Visitor", a WiFi-6 WPA3-SAE AP) rejected the Pi 5's onboard Broadcom radio with `status_code=16` ("timeout waiting for next frame in sequence"). Root cause: the BCM43455 `brcmfmac` firmware offloads SAE and only does the legacy **hunting-and-pecking** PWE method, but WiFi-6 / enterprise WPA3 APs require **hash-to-element (H2E)**.

NetworkManager 1.52 exposes no `sae-pwe` property, and wpa_supplicant in NM's D-Bus mode ignores `sae_pwe` from a `-c` global config — so there's no declarative fix. The only thing that works is poking the live supplicant: `wpa_cli set sae_pwe 2` (offer both H2E + hunt-peck).

**Verified on the office Pi 5**: associates and connects to "A Visitor" cleanly, and rejoins automatically after a full reboot.

## How — two layers, both using that proven runtime poke

- **`led-sae-h2e.service`** — boot-time oneshot (`service/led-sae-h2e.sh`) that waits for `wlan0`, sets `sae_pwe=2`, and nudges the stored connection up. Keeps H2E set across reboots for an already-stored WPA3 network. Wired into both `flash-sd.sh` (fresh cards) and `init.sh` (live provisioning), enabled alongside the other `led-*` units.
- **`apply_network()`** — when the captive portal onboards an SAE network it sets `sae_pwe=2` before bringing the connection up, so a *fresh* flash joins WPA3 without depending on the oneshot's boot timing.

Both are best-effort and harmless on open / WPA2 / non-H2E WPA3 networks.

Lockstep bump to **1.1.11**.

## Test
- `cargo test -p led-wifi-setup` — green (existing SAE/open detection tests)
- Live Pi 5: connected to "A Visitor", power-cycled, came back online on it unattended (`ssid=A Visitor sae_pwe=2 net=200`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)