### PR TITLE
fix: WASM preview fallback + RP1 inter-frame row over-bright

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -1086,7 +1086,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "led-driver"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "led-wifi-setup"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "rp1-pio"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/display-core", "crates/driver", "crates/rp1-pio", "crates/wif
 # = true` picks it up. Internal-fleet system; we ship as a unit, so
 # per-crate semver doesn't carry information for us.
 [workspace.package]
-version = "1.1.11"
+version = "1.1.12"
 # wasm-sim has its own [profile.release] (opt-level = "z", lto, single
 # codegen unit — wasm-pack defaults) that would conflict with the
 # workspace's release profile, so keep it out and build it via

--- a/crates/driver/src/sink/rp1/encoder.rs
+++ b/crates/driver/src/sink/rp1/encoder.rs
@@ -177,6 +177,21 @@ pub fn encode_frame(buf: &PixelBuffer, order: ColorOrder, out: &mut Vec<u32>) {
             prev = addr;
         }
     }
+
+    // Frame tail: park the panel blanked. `present()` DMAs one frame and
+    // blocks, then the render loop builds the next frame before the next
+    // xfer — so the PIO drains the FIFO and stalls on autopull during the
+    // gap, holding the final word's pin state (program.rs wraps to
+    // `out x, 1` and stalls there). The last loop word is addr 31's
+    // illuminate with OE active, which would leave rows 31 and 63 lit for
+    // the entire inter-frame gap and visibly over-brighten them (the
+    // "double-written" seam + bottom row). End on OE-disabled so the stall
+    // holds dark instead. The per-row anti-ghost blank moved *ahead* of
+    // each illuminate during the pipelining rework, which incidentally
+    // dropped the end-of-row blank that used to cover this — so it's
+    // restored here once, at the frame boundary, where it actually matters.
+    out.push(delay_header(BLANK_TICKS));
+    out.push(OE_DISABLED | addr_word(prev));
 }
 
 #[cfg(test)]
@@ -313,6 +328,27 @@ mod tests {
             let this_clock_addr = decode_addr(out[i * row_block + sample_offset]);
             assert_ne!(this_clock_addr, dwell_addr);
         }
+    }
+
+    #[test]
+    fn frame_ends_blanked_so_interframe_stall_holds_dark() {
+        // Between frames the PIO drains its FIFO and stalls on autopull,
+        // holding the last word's pins. If that word lights a row, the
+        // last-addressed rows (31 and 63) over-brighten for the whole gap.
+        // The stream must therefore end OE-disabled with no RGB asserted.
+        let mut out = Vec::new();
+        encode_frame(&solid(Rgb888::WHITE), ColorOrder::Rgb, &mut out);
+        let last = *out.last().expect("non-empty stream");
+        assert_ne!(
+            last & OE_DISABLED,
+            0,
+            "frame must end with OE disabled (panel blanked) so the inter-frame stall holds dark",
+        );
+        assert_eq!(
+            last & RGB_MASK,
+            0,
+            "frame must end with no RGB channel lit",
+        );
     }
 
     #[test]

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "led-dash",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "packageManager": "bun@1.2.20",
   "scripts": {

--- a/dash/src/app/components/MatrixPreview.tsx
+++ b/dash/src/app/components/MatrixPreview.tsx
@@ -193,6 +193,11 @@ export function MatrixPreview({
   // resolved would never reach the renderer and tick() would render
   // an empty default forever.
   const [rendererReady, setRendererReady] = useState(false);
+  // Set when the WASM module fails to load (browser without WebAssembly,
+  // a blocked/failed chunk fetch, etc). The renderer never comes up, so
+  // the canvas would otherwise sit on the unlit grid forever with no
+  // explanation — we show a "preview unavailable" overlay instead.
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useLayoutEffect(() => {
     const wrap = wrapperRef.current;
@@ -211,14 +216,23 @@ export function MatrixPreview({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const mod = await import("wasm-sim");
-      const renderer = new mod.Renderer(COLS, ROWS);
-      if (cancelled) {
-        renderer.free();
-        return;
+      try {
+        const mod = await import("wasm-sim");
+        const renderer = new mod.Renderer(COLS, ROWS);
+        if (cancelled) {
+          renderer.free();
+          return;
+        }
+        rendererRef.current = renderer;
+        setRendererReady(true);
+      } catch (err) {
+        // No WASM (unsupported browser, blocked/failed chunk) — surface
+        // it via the overlay rather than leaving a silent unlit grid.
+        if (!cancelled) {
+          console.error("MatrixPreview: WASM renderer failed to load", err);
+          setLoadFailed(true);
+        }
       }
-      rendererRef.current = renderer;
-      setRendererReady(true);
     })();
     return () => {
       cancelled = true;
@@ -571,6 +585,8 @@ export function MatrixPreview({
 
   const describe = () => {
     if (offline) return "LED matrix simulator — panel offline, no heartbeat.";
+    if (loadFailed)
+      return "LED matrix simulator — preview unavailable, the renderer could not load.";
     const modeName = (Object.keys(mode)[0] ?? "unknown").toLowerCase();
     const state = isOff ? "off" : isPaused ? "paused" : "live";
     if (matrixIdle) return `LED matrix simulator — ${modeName} mode, idle.`;
@@ -599,6 +615,15 @@ export function MatrixPreview({
           </span>
           <span className="text-[9px] text-(--color-text-faint)">
             no heartbeat
+          </span>
+        </div>
+      ) : loadFailed ? (
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 font-mono uppercase tracking-[0.3em] backdrop-blur-[1px]">
+          <span className="text-[11px] text-(--color-text-dim)">
+            preview unavailable
+          </span>
+          <span className="text-[9px] text-(--color-text-faint)">
+            renderer failed to load
           </span>
         </div>
       ) : matrixIdle ? (

--- a/dash/wasm-sim/Cargo.lock
+++ b/dash/wasm-sim/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sim"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "console_error_panic_hook",
  "display-core",

--- a/dash/wasm-sim/Cargo.toml
+++ b/dash/wasm-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sim"
-version = "1.1.11"
+version = "1.1.12"
 edition = "2021"
 
 # Standalone workspace. wasm-sim is `exclude`d from the parent

--- a/dash/wasm-sim/pkg/package.json
+++ b/dash/wasm-sim/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wasm-sim",
   "type": "module",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "files": [
     "wasm_sim_bg.wasm",
     "wasm_sim.js",


### PR DESCRIPTION
Two unrelated display bugs.

## (a) Blank LEDs when the WASM renderer can't load

`MatrixPreview` showed a silent unlit grid when `import("wasm-sim")` failed (browser without WebAssembly, blocked/failed chunk fetch). The rejection was unhandled, so `rendererRef` stayed null and `paint()` drew the empty substrate forever with no indication anything was wrong.

**Fix:** catch the import failure, show a *"preview unavailable / renderer failed to load"* overlay (consistent with the existing offline/idle overlays), and reflect it in the canvas `aria-label`.

## (b) Rows 31 & 63 over-bright ("double-written") on the real Pi 5 panel

The half-panel seam (row 31) and the bottom row (row 63) — both driven by the last scan address (`addr=31`) — rendered visibly brighter than the rest.

**Cause:** the pipelining rework (928ce22) moved the per-row anti-ghost blank *ahead* of each illuminate and dropped the old end-of-row blank. The frame now ends on `addr=31`'s illuminate word with **OE active**. `present()` DMAs one frame and blocks while the render loop builds the next, so the PIO drains its FIFO and **stalls on autopull** (the program wraps to `out x, 1`), holding the last word's pins — leaving rows 31/63 lit for the entire inter-frame gap.

**Fix:** emit a single OE-disabled blank at the frame tail so the inter-frame stall holds dark. The per-row anti-ghost blank stays where the rework put it; this just restores a blank at the frame boundary, where it actually matters. New encoder test asserts the stream ends blanked with no RGB asserted.

Lockstep bump to **1.1.12**.

## Test
- `cargo test -p led-driver --features rpi5` — 12 pass (incl. new `frame_ends_blanked_so_interframe_stall_holds_dark`)
- `eslint` / `tsc` clean on `MatrixPreview.tsx`
- Bug (b) is a hardware-timing fix — worth an eyeball on the panel after deploy to confirm rows 31/63 are even.

🤖 Generated with [Claude Code](https://claude.com/claude-code)