### PR TITLE
Dash frontend polish: 19 verified bug fixes, shared component library, mobile/a11y pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -1086,7 +1086,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "led-driver"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "led-wifi-setup"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "rp1-pio"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/display-core", "crates/driver", "crates/rp1-pio", "crates/wif
 # = true` picks it up. Internal-fleet system; we ship as a unit, so
 # per-crate semver doesn't carry information for us.
 [workspace.package]
-version = "1.1.12"
+version = "1.1.13"
 # wasm-sim has its own [profile.release] (opt-level = "z", lto, single
 # codegen unit — wasm-pack defaults) that would conflict with the
 # workspace's release profile, so keep it out and build it via

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "led-dash",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "packageManager": "bun@1.2.20",
   "scripts": {

--- a/dash/src/app/components/AccentButton.tsx
+++ b/dash/src/app/components/AccentButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { FOCUS_RING, PixelValue } from "./ui";
+
+/**
+ * Primary accent CTA — glyph plate on the left, tracked label, an
+ * optional right-aligned hint (text or kbd chip), and the tape-head
+ * sweep on hover. Shared by the composer's transmit button and the
+ * error boundary's retry.
+ */
+export function AccentButton({
+  glyph,
+  label,
+  hint,
+  kbd,
+  type = "button",
+  disabled = false,
+  onClick,
+}: {
+  /** Pixel-font glyph shown in the bordered plate (e.g. "▲", "↻"). */
+  glyph: string;
+  label: string;
+  /** Right-aligned faint hint text. */
+  hint?: string;
+  /** Right-aligned keybind chip (overrides `hint`'s styling slot). */
+  kbd?: string;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        "group relative flex w-full items-center justify-between overflow-hidden",
+        "border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-3 text-(--color-accent)",
+        "transition hover:bg-(--color-accent)/20 hover:shadow-[0_0_24px_-8px_var(--color-accent-fade)]",
+        "disabled:cursor-not-allowed disabled:border-(--color-border) disabled:bg-transparent disabled:text-(--color-text-faint) disabled:hover:shadow-none",
+        FOCUS_RING,
+      ].join(" ")}
+    >
+      <span className="flex items-center gap-3">
+        <span
+          aria-hidden
+          className="flex h-6 w-6 items-center justify-center border border-(--color-accent)/40 group-disabled:border-(--color-border)"
+        >
+          <PixelValue size="lg">{glyph}</PixelValue>
+        </span>
+        <span className="font-mono text-xs uppercase tracking-[0.4em]">
+          {label}
+        </span>
+      </span>
+
+      {kbd ? (
+        <span className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] opacity-70">
+          <kbd className="border border-(--color-accent)/30 bg-(--color-bg)/50 px-1.5 py-0.5 group-disabled:border-(--color-border)">
+            {kbd}
+          </kbd>
+        </span>
+      ) : hint ? (
+        <span className="font-mono text-[10px] uppercase tracking-[0.25em] opacity-70">
+          {hint}
+        </span>
+      ) : null}
+
+      {/* Sweep highlight on hover — like a tape head passing over */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 -left-1/2 w-1/2 -skew-x-12 bg-gradient-to-r from-transparent via-white/15 to-transparent transition-all duration-700 group-hover:left-full group-disabled:hidden"
+      />
+    </button>
+  );
+}

--- a/dash/src/app/components/BrightnessControl.tsx
+++ b/dash/src/app/components/BrightnessControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { panels } from "@/utils/actions";
 import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
@@ -9,8 +9,10 @@ import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
  * Global brightness fader for the active panel — a final 0–100%
  * multiplier the driver applies to every pixel, alongside pause/off.
  * Local state drives the slider for smooth dragging; writes to
- * Supabase are debounced so a drag ships one update per ~200ms, and
- * the local value re-syncs to the server value when the panel changes.
+ * Supabase are debounced so a drag ships one update per ~200ms. The
+ * local value resets on panel switch and re-syncs when the server
+ * value changes out from under us (another client / MCP call) — but
+ * not when the change is just the optimistic echo of our own write.
  */
 export function BrightnessControl({
   panelId,
@@ -21,26 +23,84 @@ export function BrightnessControl({
   brightness: number;
   disabled?: boolean;
 }) {
+  const serverPct = Math.round(brightness * 100);
+
   // Keyed on panelId: resets to the server value when switching
   // panels, but a server echo of the same panel won't fight a drag.
-  const [pct, setPct] = useSyncedFromProp(panelId, Math.round(brightness * 100));
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [pct, setPct] = useSyncedFromProp(panelId, serverPct);
 
-  useEffect(() => () => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-  }, []);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest slider value + the panel it was edited against, so the
+  // unmount flush ships the right write even after a panel switch.
+  const pendingRef = useRef(serverPct);
+  const panelIdRef = useRef(panelId);
+  // Last value the debounce actually wrote — lets us tell "server
+  // echoed our own write" apart from "someone else moved the fader".
+  const lastWrittenRef = useRef<number | null>(null);
+
+  // Remote-change resync, done during render (the React 19 adjust
+  // pattern, same as useSyncedFromProp). When the server value moves:
+  // always take the snapshot; additionally snap the slider, but only
+  // if no write is in flight (a drag isn't being raced) and the new
+  // value isn't the echo of our own debounced write.
+  const [serverSnapshot, setServerSnapshot] = useState(serverPct);
+  if (serverPct !== serverSnapshot) {
+    setServerSnapshot(serverPct);
+    // The refs here are write-coordination bookkeeping, not render
+    // inputs — they only gate whether we *also* snap the slider, and
+    // a wrong guess self-heals on the next server value. Reading them
+    // in render is deliberate; the lint can't know that.
+    // eslint-disable-next-line react-hooks/refs
+    if (timerRef.current == null && serverPct !== lastWrittenRef.current) {
+      setPct(serverPct);
+    }
+  }
+
+  // Echo consumed — clear the suppression (after render; ref writes
+  // don't belong in the render body) so a LATER remote change back to
+  // this same value (round numbers recur) isn't mistaken for our own
+  // write forever.
+  useEffect(() => {
+    if (lastWrittenRef.current === serverPct) {
+      lastWrittenRef.current = null;
+    }
+  }, [serverPct]);
+
+  // Unmount: don't drop a trailing write — flush the pending value to
+  // the panel it was edited against.
+  useEffect(
+    () => () => {
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current);
+        void panels.setBrightness.call(
+          panelIdRef.current,
+          pendingRef.current / 100,
+        );
+      }
+    },
+    [],
+  );
 
   const onChange = (next: number) => {
     setPct(next);
+    pendingRef.current = next;
+    // A new edit targeting a different panel invalidates any echo
+    // bookkeeping from the previous one.
+    if (panelIdRef.current !== panelId) lastWrittenRef.current = null;
+    panelIdRef.current = panelId;
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      lastWrittenRef.current = next;
       void panels.setBrightness.call(panelId, next / 100);
     }, 200);
   };
 
   return (
     <div
-      className="hidden items-center gap-2 border-l border-(--color-border) px-3 py-1.5 md:flex"
+      // Paints its own cell background: SectionPlate divides cells via
+      // gap-px hairlines, not per-cell borders (wrap-safe).
+      className="flex items-center gap-2 bg-gradient-to-b from-(--color-surface-2) to-(--color-surface) px-3 py-1.5"
       title={`global brightness — ${pct}%`}
     >
       <SunIcon />
@@ -53,7 +113,7 @@ export function BrightnessControl({
         disabled={disabled}
         onChange={(e) => onChange(Number(e.target.value))}
         aria-label="Global brightness"
-        className="fader w-20"
+        className="fader w-16 md:w-20"
         style={{ ["--fader-pos" as string]: `${pct}%` }}
       />
       <span className="w-7 text-right font-mono text-[9px] tabular-nums text-(--color-text-faint)">

--- a/dash/src/app/components/CheckRow.tsx
+++ b/dash/src/app/components/CheckRow.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { MicroLabel } from "./ui";
+
+/**
+ * Instrument checkbox row — square check, one size, one focus
+ * treatment. Replaces three hand-rolled copies (per-letter phase,
+ * depth shade, paint grid) that had drifted in size and ring-offset.
+ */
+export function CheckRow({
+  label,
+  hint,
+  checked,
+  onChange,
+  sigil = true,
+}: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  /** Set false for compact inline rows (e.g. paint's grid toggle). */
+  sigil?: boolean;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-3">
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <MicroLabel sigil={sigil}>{label}</MicroLabel>
+        {hint ? (
+          <span className="font-mono text-[9px] tracking-wide text-(--color-text-faint)">
+            {hint}
+          </span>
+        ) : null}
+      </span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-3.5 w-3.5 shrink-0 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)"
+      />
+    </label>
+  );
+}

--- a/dash/src/app/components/ColorPicker.tsx
+++ b/dash/src/app/components/ColorPicker.tsx
@@ -3,8 +3,10 @@
 import { Switch } from "@headlessui/react";
 import { useState } from "react";
 
+import { CheckRow } from "@/app/components/CheckRow";
 import { Fader } from "@/app/components/Fader";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
+import { FOCUS_RING, MicroLabel } from "@/app/components/ui";
 import { LED_ORANGE } from "@/utils/color";
 
 export type ColorState =
@@ -58,32 +60,37 @@ export function ColorPicker({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          {"// color"}
-        </span>
+        <MicroLabel>color</MicroLabel>
         <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
           <span className={value.mode === "rgb" ? "text-(--color-text)" : ""}>
             rgb
           </span>
+          {/* The button is the 24×36 hit box; the painted track inside
+           * stays slim so the toggle doesn't visually bloat. */}
           <Switch
             checked={value.mode === "rainbow"}
             onChange={(on) => onChange(on ? lastRainbow : lastRgb)}
-            className={[
-              "relative inline-flex h-4 w-7 items-center rounded-sm border transition",
-              value.mode === "rainbow"
-                ? "border-(--color-accent) bg-(--color-accent)/15"
-                : "border-(--color-border-strong) bg-(--color-surface-2)",
-            ].join(" ")}
+            className={`relative inline-flex h-6 w-9 items-center ${FOCUS_RING}`}
           >
             <span className="sr-only">Rainbow mode</span>
             <span
+              aria-hidden
               className={[
-                "inline-block h-2.5 w-2.5 rounded-[1px] transition-transform",
+                "inline-flex h-5 w-9 items-center rounded-sm border transition",
                 value.mode === "rainbow"
-                  ? "translate-x-3.5 bg-(--color-accent) shadow-[0_0_6px_var(--color-accent)]"
-                  : "translate-x-0.5 bg-(--color-text-dim)",
+                  ? "border-(--color-accent) bg-(--color-accent)/15"
+                  : "border-(--color-border-strong) bg-(--color-surface-2)",
               ].join(" ")}
-            />
+            >
+              <span
+                className={[
+                  "inline-block h-3.5 w-3.5 rounded-[1px] transition-transform",
+                  value.mode === "rainbow"
+                    ? "translate-x-[18px] bg-(--color-accent) shadow-[0_0_6px_var(--color-accent)]"
+                    : "translate-x-0.5 bg-(--color-text-dim)",
+                ].join(" ")}
+              />
+            </span>
           </Switch>
           <span
             className={value.mode === "rainbow" ? "text-(--color-accent)" : ""}
@@ -109,7 +116,7 @@ export function ColorPicker({
             }}
           />
           <Fader
-            label="// speed"
+            label="speed"
             value={value.speed}
             min={1}
             max={50}
@@ -119,17 +126,12 @@ export function ColorPicker({
             endpoints={["slow", "fast"]}
             ariaLabel="Rainbow speed"
           />
-          <label className="flex cursor-pointer items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-muted)">
-            <input
-              type="checkbox"
-              checked={value.perLetter}
-              onChange={(e) =>
-                commit({ ...value, perLetter: e.target.checked })
-              }
-              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
-            />
-            per-letter phase
-          </label>
+          <CheckRow
+            sigil={false}
+            label="per-letter phase"
+            checked={value.perLetter}
+            onChange={(perLetter) => commit({ ...value, perLetter })}
+          />
         </div>
       )}
     </div>

--- a/dash/src/app/components/Composer.tsx
+++ b/dash/src/app/components/Composer.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { AccentButton } from "./AccentButton";
 import { ColorPicker, type ColorState } from "./ColorPicker";
 import { ComposerShell } from "./ComposerShell";
 import { EffectsPanel, type EffectsState } from "./EffectsPanel";
+import { Alert, MicroLabel, PixelValue } from "./ui";
 
 const MAX_LEN = 64;
 
@@ -32,7 +34,18 @@ export function Composer({
   transmitFailed?: boolean;
 }) {
   const [submitting, setSubmitting] = useState(false);
+  // One-shot ACK stamp after a confirmed transmit; the NAK case is
+  // covered by the transmitFailed Alert.
+  const [acked, setAcked] = useState(false);
+  const ackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(
+    () => () => {
+      if (ackTimer.current) clearTimeout(ackTimer.current);
+    },
+    [],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,6 +57,9 @@ export function Composer({
       // failure, so a throw skips this line. An unconditional refocus
       // would re-summon the mobile keyboard even when transmit failed.
       inputRef.current?.focus();
+      setAcked(true);
+      if (ackTimer.current) clearTimeout(ackTimer.current);
+      ackTimer.current = setTimeout(() => setAcked(false), 1200);
     } catch {
       // Failure state is owned by the parent (transmitFailed); swallow
       // here so the rejection doesn't surface as an unhandled error.
@@ -70,7 +86,14 @@ export function Composer({
           : "text-(--color-phosphor)";
 
   return (
-    <ComposerShell title="composer" status={status} ariaLabel="Composer">
+    // padded=false: the form owns its padding because the tape-stripes
+    // overlay must cover the whole body, edge to edge.
+    <ComposerShell
+      title="composer"
+      status={status}
+      ariaLabel="Composer"
+      padded={false}
+    >
       <form
         onSubmit={handleSubmit}
         className={[
@@ -89,26 +112,20 @@ export function Composer({
         {/* Payload row — terminal prompt, big pixel-font counter */}
         <div className="space-y-2">
           <div className="flex items-end justify-between">
-            <label
-              htmlFor="msg"
-              className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)"
+            <MicroLabel as="label" htmlFor="msg">
+              payload
+            </MicroLabel>
+            <span
+              id="msg-count"
+              className="flex items-baseline gap-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint)"
             >
-              :: payload
-            </label>
-            <span className="flex items-baseline gap-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-              <span
-                className={`tabular-nums ${countTone}`}
-                style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-              >
+              <PixelValue className={countTone}>
                 {String(message.length).padStart(2, "0")}
-              </span>
+              </PixelValue>
               <span aria-hidden>/</span>
-              <span
-                className="tabular-nums text-(--color-text-faint)"
-                style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-              >
+              <PixelValue className="text-(--color-text-faint)">
                 {String(MAX_LEN).padStart(2, "0")}
-              </span>
+              </PixelValue>
               <span className="ml-1 normal-case lowercase">chars</span>
             </span>
           </div>
@@ -124,6 +141,9 @@ export function Composer({
               ref={inputRef}
               type="text"
               value={message}
+              // Native maxLength is exposed to AT; the slice stays as
+              // a backstop against programmatic over-long values.
+              maxLength={MAX_LEN}
               onChange={(e) =>
                 onMessageChange(e.target.value.slice(0, MAX_LEN))
               }
@@ -131,6 +151,7 @@ export function Composer({
               disabled={submitting}
               autoComplete="off"
               spellCheck={false}
+              aria-describedby="msg-count"
               className="w-full border-0 bg-transparent p-0 font-mono text-base text-(--color-text) placeholder:text-(--color-text-faint) focus:outline-none focus:ring-0 disabled:opacity-60"
             />
             {message.length === 0 ? (
@@ -175,50 +196,38 @@ export function Composer({
         <div className="border-t border-dashed border-(--color-hairline)" />
 
         {transmitFailed ? (
-          <p
-            role="alert"
-            className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)"
-          >
-            transmit failed · payload kept · retry
-          </p>
+          <Alert>transmit failed · payload kept · retry</Alert>
         ) : null}
 
-        <button
-          type="submit"
-          disabled={disabled || submitting}
-          className="group relative flex w-full items-center justify-between overflow-hidden border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-3 text-(--color-accent) transition hover:bg-(--color-accent)/20 hover:shadow-[0_0_24px_-8px_var(--color-accent-fade)] disabled:cursor-not-allowed disabled:border-(--color-border) disabled:bg-transparent disabled:text-(--color-text-faint) disabled:hover:shadow-none"
-        >
-          {/* Left: launch glyph + label */}
-          <span className="flex items-center gap-3">
-            <span
-              aria-hidden
-              className="flex h-6 w-6 items-center justify-center border border-(--color-accent)/40 group-disabled:border-(--color-border)"
-              style={{
-                fontFamily: "var(--font-pixel)",
-                fontSize: 16,
-                lineHeight: 1,
-              }}
-            >
-              ▲
-            </span>
-            <span className="font-mono text-xs uppercase tracking-[0.4em]">
-              {submitting ? "transmit ··· " : "transmit"}
-            </span>
-          </span>
-
-          {/* Right: keybind hint */}
-          <span className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] opacity-70">
-            <kbd className="border border-(--color-accent)/30 bg-(--color-bg)/50 px-1.5 py-0.5 group-disabled:border-(--color-border)">
-              ↵ enter
-            </kbd>
-          </span>
-
-          {/* Sweep highlight on hover — like a tape head passing over */}
+        <div className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <AccentButton
+              type="submit"
+              glyph="▲"
+              label={submitting ? "transmit ··· " : "transmit"}
+              kbd="↵ enter"
+              disabled={disabled || submitting}
+            />
+          </div>
+          {/* One-shot ACK stamp on confirmed transmit. The slot is a
+           * fixed-width span so the button never reflows; aria-hidden
+           * because the role=status header already announces. */}
           <span
             aria-hidden
-            className="pointer-events-none absolute inset-y-0 -left-1/2 w-1/2 -skew-x-12 bg-gradient-to-r from-transparent via-white/15 to-transparent transition-all duration-700 group-hover:left-full group-disabled:hidden"
-          />
-        </button>
+            className="flex w-9 shrink-0 justify-center"
+          >
+            <span
+              className={[
+                "border border-(--color-phosphor)/40 px-1.5 py-0.5",
+                "font-pixel text-[12px] leading-none text-(--color-phosphor)",
+                "transition-opacity duration-500",
+                acked ? "opacity-100" : "opacity-0",
+              ].join(" ")}
+            >
+              ACK
+            </span>
+          </span>
+        </div>
       </form>
     </ComposerShell>
   );

--- a/dash/src/app/components/ComposerShell.tsx
+++ b/dash/src/app/components/ComposerShell.tsx
@@ -3,13 +3,16 @@
 /**
  * Visual chrome for every per-mode composer: corner-bracketed
  * frame + heading bar with a `:: title` left tag and a tiny
- * uppercase status string on the right. Body slot owns its own
- * padding.
+ * uppercase status string on the right. The body slot gets the
+ * canonical `space-y-5 px-4 py-4` padding by default; composers
+ * that own their padding (e.g. an overlay that must cover the
+ * full body) opt out with `padded={false}`.
  */
 export function ComposerShell({
   title,
   status,
   ariaLabel,
+  padded = true,
   children,
 }: {
   /** Shown after `::` on the left side of the heading. */
@@ -17,6 +20,8 @@ export function ComposerShell({
   /** Right-aligned dim status text. */
   status?: string;
   ariaLabel?: string;
+  /** Set false when the body needs to manage its own padding. */
+  padded?: boolean;
   children: React.ReactNode;
 }) {
   return (
@@ -33,14 +38,19 @@ export function ComposerShell({
         <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
           :: {title}
         </span>
+        {/* role=status so async transitions (transmitting → ready)
+         * are announced; the changes are otherwise visual-only. */}
         {status ? (
-          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)">
+          <span
+            role="status"
+            className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-text-faint)"
+          >
             {status}
           </span>
         ) : null}
       </header>
 
-      {children}
+      {padded ? <div className="space-y-5 px-4 py-4">{children}</div> : children}
     </section>
   );
 }

--- a/dash/src/app/components/ControlRow.tsx
+++ b/dash/src/app/components/ControlRow.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { MicroLabel } from "./ui";
+
+/**
+ * Labeled control row: `:: label` (plus optional faint hint line) on
+ * the left, the control on the right. Promoted from clock.tsx's
+ * private Row — life and shapes re-implemented the same layout.
+ */
+export function ControlRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <MicroLabel>{label}</MicroLabel>
+        {hint ? (
+          <span className="font-mono text-[9px] tracking-wide text-(--color-text-faint)">
+            {hint}
+          </span>
+        ) : null}
+      </span>
+      <div className="flex shrink-0 items-center">{children}</div>
+    </div>
+  );
+}

--- a/dash/src/app/components/EffectsPanel.tsx
+++ b/dash/src/app/components/EffectsPanel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { MicroLabel, PixelValue } from "@/app/components/ui";
+
 /** Single source of truth: at/above this length the marquee is
  * auto-enabled (a static message this long won't fit the panel).
  * page.tsx imports this so the force-enable threshold can't drift. */
@@ -14,31 +16,41 @@ export function EffectsPanel({
   value,
   onChange,
   messageLength,
+  autoForcedSpeed = 10,
 }: {
   value: EffectsState;
   onChange: (e: EffectsState) => void;
   messageLength: number;
+  /** Speed the page substitutes on the wire when the marquee is
+   * auto-forced but the stored speed is still 0. Must match the
+   * page's AUTO_FORCED_DEFAULT so the readout shows what transmits. */
+  autoForcedSpeed?: number;
 }) {
   const isForced = messageLength >= FORCE_ENABLE_MARQUEE_LENGTH;
   const min = isForced ? 1 : 0;
-  // Defensive: never render below `min`.
-  const displayValue = isForced ? Math.max(value.marqueeSpeed, min) : value.marqueeSpeed;
+  // Forced + stored 0 means the page transmits `autoForcedSpeed`, so
+  // that's what we display — clamping to `min` showed 01 while the
+  // wire carried 10. Other below-min values still clamp defensively.
+  const displayValue = isForced
+    ? value.marqueeSpeed === 0
+      ? autoForcedSpeed
+      : Math.max(value.marqueeSpeed, min)
+    : value.marqueeSpeed;
   const pct = ((displayValue - min) / (MAX_SPEED - min)) * 100;
 
   return (
     <div className="space-y-2.5">
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          {"// marquee"}
-        </span>
+        <MicroLabel>marquee</MicroLabel>
         <span
           className={[
-            "font-mono text-[10px] uppercase tracking-[0.2em] tabular-nums",
+            "flex items-baseline gap-1 font-mono text-[10px] uppercase tracking-[0.2em]",
             isForced ? "text-(--color-amber)" : "text-(--color-text-faint)",
           ].join(" ")}
         >
-          {isForced ? "auto-forced · " : ""}
-          {String(displayValue).padStart(2, "0")} px·step⁻¹
+          {isForced ? <span>auto-forced ·</span> : null}
+          <PixelValue>{String(displayValue).padStart(2, "0")}</PixelValue>
+          <span>px·step⁻¹</span>
         </span>
       </div>
       <div className="flex items-center gap-3">

--- a/dash/src/app/components/EntriesList.tsx
+++ b/dash/src/app/components/EntriesList.tsx
@@ -1,13 +1,35 @@
 "use client";
 
-import { Bars3Icon, TrashIcon } from "@heroicons/react/16/solid";
-import { AnimatePresence, motion, Reorder } from "framer-motion";
-import { useContext, useState } from "react";
+import {
+  Bars3Icon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  TrashIcon,
+} from "@heroicons/react/16/solid";
+import {
+  AnimatePresence,
+  Reorder,
+  useDragControls,
+} from "framer-motion";
+import { useContext, useEffect, useRef, useState } from "react";
 
 import { PanelContext } from "@/app/context";
+import {
+  Alert,
+  EmptyState,
+  FOCUS_RING,
+  Lamp,
+  PixelValue,
+} from "@/app/components/ui";
 import { entries, type TextEntryItem } from "@/utils/actions";
+import { pad } from "@/utils/format";
 
 const VISIBLE_SLOTS = 7;
+
+// How long an armed delete confirm stays live before disarming itself.
+// Long enough to read and reach the button, short enough that a
+// forgotten confirm isn't a landmine for the next tap.
+const CONFIRM_DISARM_MS = 4000;
 
 export function EntriesList() {
   const panelId = useContext(PanelContext);
@@ -27,31 +49,39 @@ export function EntriesList() {
   // (or the explicit confirm button) commits. Guards against fat-finger
   // deletes from the tiny per-row control.
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
+  // An armed confirm must not survive a panel switch — the next panel's
+  // queue would render with a live "delete" button on whatever row
+  // happens to share the id-less slot. Render-time adjust, matching the
+  // `effectsPanelId` idiom in page.tsx.
+  const [confirmPanelId, setConfirmPanelId] = useState(panelId);
+  if (confirmPanelId !== panelId) {
+    setConfirmPanelId(panelId);
+    setConfirmingId(null);
+  }
+
+  // Auto-disarm a confirm the user walked away from.
+  useEffect(() => {
+    if (confirmingId === null) return;
+    const timer = setTimeout(() => setConfirmingId(null), CONFIRM_DISARM_MS);
+    return () => clearTimeout(timer);
+  }, [confirmingId]);
+
   const serverItems = entriesData.data?.entries ?? [];
   const items = dragOrder ?? serverItems;
 
   if (entriesData.isLoading) {
-    return <Empty muted>loading messages ···</Empty>;
+    return <EmptyState variant="block" title="loading messages ···" />;
   }
   if (entriesData.error || !entriesData.data) {
-    return (
-      <div className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-4 py-8 text-center">
-        <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-danger)">
-          err: read failed
-        </p>
-      </div>
-    );
+    return <Alert center>err: read failed</Alert>;
   }
   if (items.length === 0) {
     return (
-      <Empty>
-        <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          nothing on the wall
-        </p>
-        <p className="font-mono text-[9px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-          transmit a payload to begin
-        </p>
-      </Empty>
+      <EmptyState
+        title="nothing on the wall"
+        detail="transmit a payload to begin"
+      />
     );
   }
 
@@ -89,6 +119,23 @@ export function EntriesList() {
     }
   };
 
+  // Keyboard/tap alternative to drag — order decides what's on-air, so
+  // it can't be drag-only. Swap against the SERVER order, not the
+  // rendered one, so a stale mid-drag snapshot can't be committed.
+  const handleMove = async (entry: TextEntryItem, direction: -1 | 1) => {
+    const ids = serverItems.map((e) => e.id);
+    const from = ids.indexOf(entry.id);
+    const to = from + direction;
+    if (from === -1 || to < 0 || to >= ids.length) return;
+    [ids[from], ids[to]] = [ids[to], ids[from]];
+    setActionError(null);
+    try {
+      await entries.reorder.call(panelId, ids);
+    } catch {
+      setActionError("reorder failed · order restored");
+    }
+  };
+
   const handleDelete = async (entry: TextEntryItem) => {
     setConfirmingId(null);
     setActionError(null);
@@ -104,31 +151,42 @@ export function EntriesList() {
       <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.25em] tabular-nums text-(--color-text-faint)">
         <span className="flex items-baseline gap-2">
           <span>loaded</span>
-          <span
-            className="text-(--color-text)"
-            style={{ fontFamily: "var(--font-pixel)", fontSize: 13 }}
-          >
-            {String(items.length).padStart(2, "0")}
-          </span>
+          <PixelValue size="sm" className="text-(--color-text)">
+            {pad(items.length)}
+          </PixelValue>
           <span>·</span>
           <span>on-air</span>
-          <span
-            className="text-(--color-phosphor)"
-            style={{ fontFamily: "var(--font-pixel)", fontSize: 13 }}
-          >
-            {String(visibleCount).padStart(2, "0")}
+          <PixelValue size="sm" className="text-(--color-phosphor)">
+            {pad(visibleCount)}
+          </PixelValue>
+          {/* Seven-slot VU bargraph mirroring the on-air window; the
+              text counts carry the info for screen readers. Bottom
+              edges sit on the counts baseline (a textless flex item's
+              baseline is its bottom margin edge). */}
+          <span aria-hidden className="flex gap-px">
+            {Array.from({ length: VISIBLE_SLOTS }, (_, slot) => (
+              <span
+                key={slot}
+                className={[
+                  "h-2 w-1",
+                  slot < visibleCount ? "bg-(--color-phosphor)" : "bg-white/5",
+                ].join(" ")}
+                style={
+                  slot < visibleCount
+                    ? { boxShadow: "0 0 4px var(--color-phosphor)" }
+                    : undefined
+                }
+              />
+            ))}
+            {items.length > VISIBLE_SLOTS ? (
+              // Overflow cell: messages queued beyond the on-air window.
+              <span className="h-2 w-1 animate-pulse bg-(--color-amber)" />
+            ) : null}
           </span>
         </span>
       </div>
 
-      {actionError ? (
-        <p
-          role="alert"
-          className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)"
-        >
-          {actionError}
-        </p>
-      ) : null}
+      {actionError ? <Alert>{actionError}</Alert> : null}
 
       <Reorder.Group
         axis="y"
@@ -137,158 +195,221 @@ export function EntriesList() {
         className="bezel-recessed flex flex-col gap-px border border-(--color-border) bg-(--color-surface)/40"
       >
         <AnimatePresence initial={false}>
-          {items.map((entry, index) => {
-            const visible = index >= scroll && index < scroll + VISIBLE_SLOTS;
-            return (
-              <Reorder.Item
-                key={entry.id}
-                value={entry}
-                // Commit the final order once the drag settles, not on
-                // every intermediate onReorder move.
-                onDragEnd={() => void handleReorderCommit()}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.15 }}
-                whileDrag={{
-                  scale: 1.01,
-                  boxShadow:
-                    "0 4px 16px rgba(0,0,0,0.6), 0 0 0 1px var(--color-accent)",
-                  zIndex: 10,
-                }}
-                className={[
-                  "group relative flex cursor-grab select-none items-center gap-3 border-l-2 px-3 py-2 transition-colors active:cursor-grabbing",
-                  visible
-                    ? "border-(--color-phosphor) bg-(--color-phosphor)/5"
-                    : "border-transparent bg-transparent",
-                ].join(" ")}
-              >
-                <Bars3Icon
-                  aria-hidden
-                  className={[
-                    "h-3 w-3 shrink-0",
-                    visible
-                      ? "text-(--color-phosphor)/70"
-                      : "text-(--color-text-faint)",
-                  ].join(" ")}
-                />
-
-                <span
-                  aria-hidden
-                  className={[
-                    "shrink-0 tabular-nums",
-                    visible
-                      ? "text-(--color-phosphor)"
-                      : "text-(--color-text-faint)",
-                  ].join(" ")}
-                  style={{
-                    fontFamily: "var(--font-pixel)",
-                    fontSize: 13,
-                    lineHeight: 1,
-                  }}
-                >
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-
-                <span
-                  className={[
-                    "min-w-0 flex-1 truncate font-mono text-sm",
-                    visible
-                      ? "text-(--color-text)"
-                      : "text-(--color-text-muted)",
-                  ].join(" ")}
-                >
-                  {entry.data.text}
-                </span>
-
-                {visible ? (
-                  <span
-                    aria-hidden
-                    className="flex shrink-0 items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.25em] text-(--color-phosphor)"
-                  >
-                    <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-(--color-phosphor)" />
-                    on-air
-                  </span>
-                ) : (
-                  <span
-                    aria-hidden
-                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.25em] text-(--color-text-faint)"
-                  >
-                    queued
-                  </span>
-                )}
-
-                {confirmingId === entry.id ? (
-                  // Two-step confirm: avoids an irreversible delete from
-                  // a single mis-tap on the small per-row control.
-                  <span className="flex shrink-0 items-center gap-1">
-                    <motion.button
-                      type="button"
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={() => void handleDelete(entry)}
-                      className="flex min-h-8 cursor-pointer items-center border border-(--color-danger)/50 bg-(--color-danger)/10 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger) transition-colors hover:bg-(--color-danger)/20"
-                      aria-label={`Confirm delete message "${entry.data.text}"`}
-                    >
-                      delete
-                    </motion.button>
-                    <motion.button
-                      type="button"
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={() => setConfirmingId(null)}
-                      className="flex min-h-8 cursor-pointer items-center px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint) transition-colors hover:text-(--color-text)"
-                      aria-label="Cancel delete"
-                    >
-                      cancel
-                    </motion.button>
-                  </span>
-                ) : (
-                  <motion.button
-                    type="button"
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={() => {
-                      setActionError(null);
-                      setConfirmingId(entry.id);
-                    }}
-                    // Touch devices don't fire :hover, so the
-                    // group-hover gate would render the button
-                    // unreachable; show it always there. 32px min hit
-                    // target for touch (the icon stays small).
-                    className="flex min-h-8 min-w-8 shrink-0 cursor-pointer items-center justify-center text-(--color-text-faint) transition-colors hover:text-(--color-danger) sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
-                    aria-label={`Delete message "${entry.data.text}"`}
-                  >
-                    <TrashIcon className="h-4 w-4" />
-                  </motion.button>
-                )}
-              </Reorder.Item>
-            );
-          })}
+          {items.map((entry, index) => (
+            <Row
+              key={entry.id}
+              entry={entry}
+              index={index}
+              total={items.length}
+              visible={index >= scroll && index < scroll + VISIBLE_SLOTS}
+              confirming={confirmingId === entry.id}
+              onArm={() => {
+                setActionError(null);
+                setConfirmingId(entry.id);
+              }}
+              onCancel={() => setConfirmingId(null)}
+              onDelete={() => void handleDelete(entry)}
+              onMove={(direction) => void handleMove(entry, direction)}
+              onDragCommit={() => void handleReorderCommit()}
+            />
+          ))}
         </AnimatePresence>
       </Reorder.Group>
     </div>
   );
 }
 
-function Empty({
-  muted,
-  children,
+// Per-row subcomponent so each row owns its useDragControls instance.
+function Row({
+  entry,
+  index,
+  total,
+  visible,
+  confirming,
+  onArm,
+  onCancel,
+  onDelete,
+  onMove,
+  onDragCommit,
 }: {
-  muted?: boolean;
-  children: React.ReactNode;
+  entry: TextEntryItem;
+  index: number;
+  total: number;
+  visible: boolean;
+  confirming: boolean;
+  onArm: () => void;
+  onCancel: () => void;
+  onDelete: () => void;
+  onMove: (direction: -1 | 1) => void;
+  onDragCommit: () => void;
 }) {
+  // Drag starts ONLY from the handle button (dragListener={false}).
+  // With the whole row draggable, a touch swipe over the queue
+  // reordered instead of scrolling the page.
+  const controls = useDragControls();
+  const text = entry.data.text;
+
+  // When the armed confirm disarms (cancel / Escape / auto-timeout),
+  // the focused confirm button unmounts and keyboard focus falls to
+  // <body> — restore it to the trash button so the user keeps their
+  // place in the queue. Gated on focus actually being orphaned, so a
+  // 4s auto-disarm can't yank focus from wherever the user went next.
+  const trashRef = useRef<HTMLButtonElement>(null);
+  const wasConfirming = useRef(false);
+  useEffect(() => {
+    if (
+      wasConfirming.current &&
+      !confirming &&
+      document.activeElement === document.body
+    ) {
+      trashRef.current?.focus();
+    }
+    wasConfirming.current = confirming;
+  }, [confirming]);
+  // Shared visibility gate for the per-row controls: always reachable
+  // on touch (no :hover there), revealed on hover/focus on sm+.
+  const revealOnHover =
+    "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100";
+
   return (
-    <div
+    <Reorder.Item
+      value={entry}
+      dragListener={false}
+      dragControls={controls}
+      // Commit the final order once the drag settles, not on every
+      // intermediate onReorder move.
+      onDragEnd={onDragCommit}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+      whileDrag={{
+        scale: 1.01,
+        boxShadow:
+          "0 4px 16px rgba(0,0,0,0.6), 0 0 0 1px var(--color-accent)",
+        zIndex: 10,
+      }}
       className={[
-        "flex flex-col items-center gap-2 border border-dashed border-(--color-border) px-4 py-10 text-center",
-        muted ? "bg-(--color-surface)/30" : "bg-(--color-surface)/40",
+        "group relative flex select-none items-center gap-2 border-l-2 px-3 py-2 transition-colors",
+        visible
+          ? "border-(--color-phosphor) bg-(--color-phosphor)/5"
+          : "border-transparent bg-transparent",
       ].join(" ")}
     >
-      {typeof children === "string" ? (
-        <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          {children}
-        </p>
+      <button
+        type="button"
+        // touch-none so the browser doesn't claim the gesture for
+        // scrolling once a drag starts from the handle.
+        onPointerDown={(e) => controls.start(e)}
+        className={[
+          "flex min-h-8 min-w-8 shrink-0 cursor-grab touch-none items-center justify-center active:cursor-grabbing",
+          visible ? "text-(--color-phosphor)/70" : "text-(--color-text-faint)",
+          FOCUS_RING,
+        ].join(" ")}
+        aria-label={`Drag to reorder "${text}"`}
+      >
+        <Bars3Icon aria-hidden className="h-3 w-3" />
+      </button>
+
+      {/* Decorative slot number — position is already conveyed by list
+          order and the move-button labels. */}
+      <span aria-hidden className="shrink-0">
+        <PixelValue
+          size="sm"
+          className={
+            visible ? "text-(--color-phosphor)" : "text-(--color-text-faint)"
+          }
+        >
+          {pad(index + 1)}
+        </PixelValue>
+      </span>
+
+      <span
+        className={[
+          "min-w-0 flex-1 truncate font-mono text-sm",
+          visible ? "text-(--color-text)" : "text-(--color-text-muted)",
+        ].join(" ")}
+      >
+        {text}
+      </span>
+
+      {visible ? (
+        // The chip text stays in the a11y tree — on-air vs queued is the
+        // one piece of state that matters here. Only the lamp is
+        // decorative (Lamp is aria-hidden internally).
+        <span className="flex shrink-0 items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.25em] text-(--color-phosphor)">
+          <Lamp tone="phosphor" pulse />
+          on-air
+        </span>
       ) : (
-        children
+        <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.25em] text-(--color-text-faint)">
+          queued
+        </span>
       )}
-    </div>
+
+      <span className={`flex shrink-0 items-center ${revealOnHover}`}>
+        <button
+          type="button"
+          onClick={() => onMove(-1)}
+          disabled={index === 0}
+          className={`flex min-h-8 min-w-8 cursor-pointer items-center justify-center text-(--color-text-faint) transition-colors hover:text-(--color-text) disabled:cursor-default disabled:text-(--color-text-faint)/30 ${FOCUS_RING}`}
+          aria-label={`Move "${text}" up to position ${index}`}
+        >
+          <ChevronUpIcon className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onMove(1)}
+          disabled={index === total - 1}
+          className={`flex min-h-8 min-w-8 cursor-pointer items-center justify-center text-(--color-text-faint) transition-colors hover:text-(--color-text) disabled:cursor-default disabled:text-(--color-text-faint)/30 ${FOCUS_RING}`}
+          aria-label={`Move "${text}" down to position ${index + 2}`}
+        >
+          <ChevronDownIcon className="h-4 w-4" />
+        </button>
+      </span>
+
+      {confirming ? (
+        // Two-step confirm: avoids an irreversible delete from a single
+        // mis-tap on the small per-row control. Escape backs out.
+        <span
+          className="flex shrink-0 items-center gap-1"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") onCancel();
+          }}
+        >
+          <button
+            type="button"
+            // Pull focus so the keyboard flow is arm → Enter/Escape.
+            autoFocus
+            onClick={onDelete}
+            className={`flex min-h-8 cursor-pointer items-center border border-(--color-danger)/50 bg-(--color-danger)/10 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger) transition-colors hover:bg-(--color-danger)/20 ${FOCUS_RING}`}
+            aria-label={`Confirm delete message "${text}"`}
+          >
+            delete
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className={`flex min-h-8 cursor-pointer items-center px-2 py-1 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint) transition-colors hover:text-(--color-text) ${FOCUS_RING}`}
+            aria-label="Cancel delete"
+          >
+            cancel
+          </button>
+        </span>
+      ) : (
+        <button
+          type="button"
+          ref={trashRef}
+          onClick={onArm}
+          // Touch devices don't fire :hover, so the group-hover gate
+          // would render the button unreachable; show it always there.
+          // 32px min hit target for touch (the icon stays small).
+          className={`flex min-h-8 min-w-8 shrink-0 cursor-pointer items-center justify-center text-(--color-text-faint) transition-colors hover:text-(--color-danger) ${revealOnHover} ${FOCUS_RING}`}
+          aria-label={`Delete message "${text}"`}
+        >
+          <TrashIcon className="h-4 w-4" />
+        </button>
+      )}
+    </Reorder.Item>
   );
 }

--- a/dash/src/app/components/Fader.tsx
+++ b/dash/src/app/components/Fader.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { FOCUS_RING, MicroLabel, PixelValue } from "./ui";
+
 /**
  * Shared labeled slider. Replaces the hand-rolled `pct` slider +
  * preset-chip rows duplicated across shapes / gif / life. The native
@@ -7,9 +9,10 @@
  * thumb takes focus) so this is keyboard-operable for free; the
  * `.fader` class (globals.css) draws the LED-orange filled track.
  *
- * `presets` renders snap chips below the slider. `format` controls the
- * right-aligned value readout; `endpoints` labels the slider extremes
- * (e.g. slow/fast, wire/solid).
+ * `label` is plain text — the `::` sigil is rendered here so callers
+ * can't drift the prefix. `presets` renders snap chips below the
+ * slider. `format` controls the right-aligned value readout;
+ * `endpoints` labels the slider extremes (e.g. slow/fast, wire/solid).
  */
 export function Fader({
   label,
@@ -45,15 +48,8 @@ export function Fader({
   return (
     <div className="space-y-2.5">
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-          {label}
-        </span>
-        <span
-          className="tabular-nums text-(--color-text)"
-          style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-        >
-          {format(value)}
-        </span>
+        <MicroLabel>{label}</MicroLabel>
+        <PixelValue className="text-(--color-text)">{format(value)}</PixelValue>
       </div>
 
       <div className="flex items-center gap-3">
@@ -90,8 +86,8 @@ export function Fader({
                 type="button"
                 onClick={() => onChange(p)}
                 className={[
-                  "border px-2 py-1 font-mono text-[9px] uppercase tracking-[0.25em] transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
+                  "border px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.25em] transition-colors",
+                  FOCUS_RING,
                   active
                     ? "border-(--color-accent) bg-(--color-accent)/15 text-(--color-accent)"
                     : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",

--- a/dash/src/app/components/InstrumentHeader.tsx
+++ b/dash/src/app/components/InstrumentHeader.tsx
@@ -3,7 +3,9 @@
 import { useMemo } from "react";
 
 import { LiveDot } from "@/app/components/LiveDot";
+import { PixelValue } from "@/app/components/ui";
 import { panels, type RealtimeStatus } from "@/utils/actions";
+import { pad } from "@/utils/format";
 import { isOffline } from "@/utils/offline";
 import { useNow } from "@/utils/useNow";
 
@@ -39,17 +41,19 @@ export function InstrumentHeader({
          * because the pixel font has different metrics from the mono
          * tag and would visually drift on baseline alignment. */}
         <div className="flex min-w-0 items-center gap-3">
+          {/* Wordmark — PixelValue carries the face/size; the span
+           * keeps only the CRT glow, which PixelValue doesn't own. */}
           <span
             aria-hidden
-            className="select-none leading-none text-(--color-accent)"
+            className="select-none"
             style={{
-              fontFamily: "var(--font-pixel)",
-              fontSize: 24,
               textShadow:
                 "0 0 12px var(--color-accent-fade), 0 0 4px color-mix(in oklch, var(--color-accent) 40%, transparent)",
             }}
           >
-            ziyad&apos;s leds
+            <PixelValue size="xl" className="text-(--color-accent)">
+              ziyad&apos;s leds
+            </PixelValue>
           </span>
         </div>
 
@@ -103,22 +107,11 @@ function Telemetry({
       <span className="font-mono text-[9px] leading-none uppercase tracking-[0.3em] text-(--color-text-faint)">
         {label}
       </span>
-      <span
-        className={`tabular-nums leading-none ${valueClass}`}
-        style={{
-          fontFamily: "var(--font-pixel)",
-          fontSize: 16,
-          letterSpacing: "0.02em",
-        }}
-      >
+      <PixelValue size="lg" className={`tracking-[0.02em] ${valueClass}`}>
         {value}
-      </span>
+      </PixelValue>
     </div>
   );
-}
-
-function pad(n: number) {
-  return String(n).padStart(2, "0");
 }
 
 function fleetStats(rows: PanelRow[], now: number) {

--- a/dash/src/app/components/MatrixPreview.tsx
+++ b/dash/src/app/components/MatrixPreview.tsx
@@ -11,9 +11,11 @@ import {
 } from "react";
 
 import { PanelContext } from "@/app/context";
+import { EmptyState } from "@/app/components/ui";
 import type { Mode, WireColor } from "@/app/scenes/types";
 import { entries as entriesActions } from "@/utils/actions";
 import { LED_ORANGE } from "@/utils/color";
+import { useReducedMotion } from "@/utils/useReducedMotion";
 
 const ROWS = 64;
 const COLS = 64;
@@ -148,6 +150,34 @@ class GlowCache {
     octx.fillRect(0, 0, size, size);
     return off;
   }
+}
+
+/**
+ * The simulator's outer chrome — square bezel + vignette. Exported so
+ * the page's no-panels placeholder shares the exact frame instead of
+ * hand-copying it (and drifting, as the old rounded copy did).
+ * Accepts a ref so MatrixPreview can keep its ResizeObserver sizing
+ * against the same element that carries the padding.
+ */
+export function MatrixFrame({
+  ref,
+  children,
+}: {
+  ref?: React.Ref<HTMLDivElement>;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      ref={ref}
+      className="relative overflow-hidden border border-(--color-border) bg-black p-3 shadow-2xl shadow-black/60"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_55%,rgba(0,0,0,0.65))]"
+      />
+      {children}
+    </div>
+  );
 }
 
 /**
@@ -297,7 +327,12 @@ export function MatrixPreview({
   // The loop only needs to run when something can actually change on
   // screen. When the panel is offline/paused/off or the scene is
   // static, we render a single frame and idle until state changes.
-  const shouldAnimate = !offline && !isPaused && !isOff && isAnimatedMode;
+  // prefers-reduced-motion folds in here because the CSS reduce rules
+  // can't reach a rAF/WASM loop — the idle path still paints one
+  // static frame per scene change, just no sustained animation.
+  const reducedMotion = useReducedMotion();
+  const shouldAnimate =
+    !offline && !isPaused && !isOff && isAnimatedMode && !reducedMotion;
 
   // Dedupe scene pushes without stringifying the whole frame on every
   // rebuild: a loaded gif scene is ~720KB and clock rebuilds at 1Hz.
@@ -309,6 +344,10 @@ export function MatrixPreview({
   // Bumped only when the scene the renderer holds actually changed, so
   // an idle (static-mode) loop knows to repaint exactly once.
   const [sceneVersion, setSceneVersion] = useState(0);
+  // Set when the renderer threw on a pushed scene (serde rejects shapes
+  // the dash's cheap parsing lets through, e.g. a corrupted bitmap with
+  // out-of-range channel values). Cleared by the next successful push.
+  const [sceneRejected, setSceneRejected] = useState(false);
   useEffect(() => {
     const renderer = rendererRef.current;
     // Don't record the dedupe key until we actually have a renderer to
@@ -320,8 +359,19 @@ export function MatrixPreview({
     const m = frame.mode;
     // Bitmap modes carry huge arrays the structural key can't cheaply
     // summarize; track the array reference so reference-stable SWR churn
-    // skips the stringify. Non-bitmap modes leave this null.
-    const bitmap = "Image" in m ? m.Image.bitmap : "Gif" in m ? m.Gif.frames : null;
+    // skips the stringify. Life is in this set too: its cell count is
+    // constant across generations, so the key alone would dedupe every
+    // generation after the first and freeze the preview on the seed —
+    // the cells array reference is what changes when the lattice
+    // advances. Non-bitmap modes leave this null.
+    const bitmap =
+      "Image" in m
+        ? m.Image.bitmap
+        : "Gif" in m
+          ? m.Gif.frames
+          : "Life" in m
+            ? m.Life.cells
+            : null;
 
     // Fast path: structural key unchanged AND (for bitmap modes) the
     // payload array is reference-identical → nothing the renderer cares
@@ -336,9 +386,26 @@ export function MatrixPreview({
     // Only stringify when something actually changed — for a 720KB gif
     // this now happens on real updates, not on every SWR refresh.
     const json = JSON.stringify(frame);
+    // setSceneJson deserializes in Rust and throws on shape mismatches
+    // — uncaught, that escapes the effect into the route error boundary
+    // and retry just re-pushes and crashes again. Contain it here, and
+    // record the dedupe refs only on success: marking a rejected scene
+    // as pushed would also suppress the retry once the renderer exists
+    // for a corrected scene with the same structural key.
+    try {
+      renderer.setSceneJson(json);
+    } catch (err) {
+      console.error("MatrixPreview: renderer rejected scene", err);
+      // Mirrors an external outcome (the WASM renderer threw), not
+      // state derivable during render — the lint heuristic is a false
+      // positive here.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSceneRejected(true);
+      return;
+    }
     lastKeyRef.current = key;
     lastBitmapRef.current = bitmap;
-    renderer.setSceneJson(json);
+    setSceneRejected(false);
     // Wake an idled loop so it repaints this new scene exactly once.
     setSceneVersion((v) => v + 1);
   }, [frame, rendererReady]);
@@ -587,6 +654,8 @@ export function MatrixPreview({
     if (offline) return "LED matrix simulator — panel offline, no heartbeat.";
     if (loadFailed)
       return "LED matrix simulator — preview unavailable, the renderer could not load.";
+    if (sceneRejected)
+      return "LED matrix simulator — scene rejected, mode config failed validation.";
     const modeName = (Object.keys(mode)[0] ?? "unknown").toLowerCase();
     const state = isOff ? "off" : isPaused ? "paused" : "live";
     if (matrixIdle) return `LED matrix simulator — ${modeName} mode, idle.`;
@@ -594,14 +663,7 @@ export function MatrixPreview({
   };
 
   return (
-    <div
-      ref={wrapperRef}
-      className="relative overflow-hidden rounded-2xl border border-(--color-border) bg-black p-3 shadow-2xl shadow-black/60"
-    >
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_55%,rgba(0,0,0,0.65))]"
-      />
+    <MatrixFrame ref={wrapperRef}>
       <canvas
         ref={canvasRef}
         role="img"
@@ -609,29 +671,34 @@ export function MatrixPreview({
         className="relative mx-auto block"
       />
       {offline ? (
-        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 font-mono uppercase tracking-[0.3em] backdrop-blur-[1px]">
-          <span className="text-[11px] text-(--color-danger)">
-            panel offline
-          </span>
-          <span className="text-[9px] text-(--color-text-faint)">
-            no heartbeat
-          </span>
-        </div>
+        <EmptyState
+          variant="overlay"
+          tone="danger"
+          title="panel offline"
+          detail="no heartbeat"
+        />
       ) : loadFailed ? (
-        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 font-mono uppercase tracking-[0.3em] backdrop-blur-[1px]">
-          <span className="text-[11px] text-(--color-text-dim)">
-            preview unavailable
-          </span>
-          <span className="text-[9px] text-(--color-text-faint)">
-            renderer failed to load
-          </span>
-        </div>
+        <EmptyState
+          variant="overlay"
+          title="preview unavailable"
+          detail="renderer failed to load"
+        />
+      ) : sceneRejected ? (
+        <EmptyState
+          variant="overlay"
+          title="scene rejected"
+          detail="mode config failed validation"
+        />
       ) : matrixIdle ? (
+        // Not an error state — it sits over a live-looking unlit grid,
+        // so no scrim/blur. Hand-rolled rather than fighting the overlay
+        // variant's bg/blur with override classes whose winner depends
+        // on stylesheet order, not class order.
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
           matrix idle
         </div>
       ) : null}
-    </div>
+    </MatrixFrame>
   );
 }
 

--- a/dash/src/app/components/PanelSwitcher.tsx
+++ b/dash/src/app/components/PanelSwitcher.tsx
@@ -3,7 +3,16 @@
 import { PowerIcon } from "@heroicons/react/24/outline";
 import { useMemo, useRef } from "react";
 
+import {
+  Alert,
+  EmptyState,
+  FOCUS_RING,
+  Lamp,
+  type LampTone,
+  PixelValue,
+} from "@/app/components/ui";
 import { panels } from "@/utils/actions";
+import { pad } from "@/utils/format";
 import { isOffline, relativeTime } from "@/utils/offline";
 import { useNow } from "@/utils/useNow";
 
@@ -151,27 +160,25 @@ export function PanelSwitcher({
         <span className="uppercase tracking-[0.3em] text-(--color-text-dim)">
           :: target
         </span>
-        <span
-          className="text-(--color-text-faint) tabular-nums"
-          style={{ fontFamily: "var(--font-pixel)", fontSize: 13 }}
-        >
-          {list.length.toString().padStart(2, "0")}
-        </span>
+        <PixelValue size="sm" className="text-(--color-text-faint)">
+          {pad(list.length)}
+        </PixelValue>
       </div>
 
-      {error ? (
-        <div className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-2 py-1.5 text-[10px] text-(--color-danger)">
-          err: panel index unreachable
-        </div>
-      ) : null}
+      {error ? <Alert>err: panel index unreachable</Alert> : null}
 
       {!error && list.length === 0 ? (
-        <div className="border border-dashed border-(--color-border) px-2 py-3 text-center text-[10px] text-(--color-text-dim)">
-          no panels registered
-        </div>
+        <EmptyState title="no panels registered" variant="dashed" />
       ) : null}
 
-      <div role="tablist" aria-label="Panel" className="flex flex-col gap-px">
+      {/* Vertical rail on lg+; below lg the page reorders the switcher
+        * above the simulator, so collapse to a horizontal strip of
+        * chips that scrolls on phones. */}
+      <div
+        role="tablist"
+        aria-label="Panel"
+        className="flex flex-row gap-px overflow-x-auto lg:flex-col"
+      >
         {list.map((p, i) => {
           const active = p.id === panelId;
           const versionState = versionStates[i];
@@ -196,19 +203,24 @@ export function PanelSwitcher({
             ? `${p.name} — offline, ${heartbeatLabel}`
             : `${p.name} — ${state}, ${versionClause(p.driver_version, versionState)}`;
 
-          // Status indicator: phosphor lamp for live-active, dim for
-          // off, amber for paused, danger for offline, dim for
+          // Status lamp: accent pulse for live-active, faint for off,
+          // amber for paused, danger for offline, dimmed phosphor for
           // inactive-online. Offline takes priority (truth check),
           // then off (user explicitly killed it), then paused.
-          const lamp = offline
-            ? { class: "bg-(--color-danger)", glow: "var(--color-danger)" }
+          const lamp: {
+            tone: LampTone;
+            pulse?: boolean;
+            glow?: boolean;
+            className?: string;
+          } = offline
+            ? { tone: "danger" }
             : p.is_off
-              ? { class: "bg-(--color-text-faint)", glow: "transparent" }
+              ? { tone: "faint", glow: false }
               : p.is_paused
-                ? { class: "bg-(--color-amber)", glow: "var(--color-amber)" }
+                ? { tone: "amber" }
                 : active
-                  ? { class: "bg-(--color-accent)", glow: "var(--color-accent)" }
-                  : { class: "bg-(--color-phosphor)/40", glow: "transparent" };
+                  ? { tone: "accent", pulse: true }
+                  : { tone: "phosphor", glow: false, className: "opacity-40" };
 
           return (
             <button
@@ -226,7 +238,10 @@ export function PanelSwitcher({
               onKeyDown={(e) => onKeyDown(e, i)}
               onClick={() => onChange(p.id)}
               className={[
-                "group relative flex flex-col gap-0.5 border-l-2 px-2 py-1.5 text-left transition-colors",
+                "group relative flex shrink-0 flex-col gap-0.5 border-l-2 px-2 py-1.5 text-left transition-colors",
+                "min-w-32 lg:min-w-0",
+                FOCUS_RING,
+                "focus-visible:ring-inset",
                 active
                   ? offline
                     ? "border-(--color-danger) bg-(--color-danger)/10 text-(--color-danger)"
@@ -237,41 +252,28 @@ export function PanelSwitcher({
             >
               <span className="flex items-center gap-2">
                 {/* Channel index — tape-deck preset */}
-                <span
-                  aria-hidden
-                  className="shrink-0 text-(--color-text-faint) tabular-nums"
-                  style={{
-                    fontFamily: "var(--font-pixel)",
-                    fontSize: 12,
-                    lineHeight: 1,
-                  }}
+                <PixelValue
+                  size="sm"
+                  className="shrink-0 text-(--color-text-faint)"
                 >
-                  {(i + 1).toString().padStart(2, "0")}
-                </span>
+                  {pad(i + 1)}
+                </PixelValue>
 
                 {/* Status lamp */}
-                <span
-                  aria-hidden
-                  className={[
-                    "h-1.5 w-1.5 shrink-0 rounded-[1px]",
-                    lamp.class,
-                    active && !offline && !p.is_paused && !p.is_off
-                      ? "animate-pulse"
-                      : "",
-                  ].join(" ")}
-                  style={{
-                    boxShadow:
-                      lamp.glow !== "transparent"
-                        ? `0 0 6px ${lamp.glow}`
-                        : "none",
-                  }}
+                <Lamp
+                  tone={lamp.tone}
+                  pulse={lamp.pulse}
+                  glow={lamp.glow}
+                  className={lamp.className}
                 />
 
-                {/* Panel name */}
+                {/* Panel name. Offline keeps full contrast — the
+                 * line-through + chip carry the signal; dimming on
+                 * top pushed the 11px text under AA. */}
                 <span
                   className={[
                     "min-w-0 flex-1 truncate lowercase tracking-wide",
-                    offline ? "line-through opacity-60" : "",
+                    offline ? "line-through" : "",
                   ].join(" ")}
                 >
                   {p.name}
@@ -289,7 +291,7 @@ export function PanelSwitcher({
                 {p.is_paused ? (
                   <span
                     aria-hidden
-                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-amber)/80"
+                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-amber)"
                   >
                     ❚❚
                   </span>
@@ -297,20 +299,29 @@ export function PanelSwitcher({
                 {offline ? (
                   <span
                     aria-hidden
-                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger)/80"
+                    className="shrink-0 font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-danger)"
                   >
                     offline
                   </span>
                 ) : null}
               </span>
 
-              {/* Secondary row — version + heartbeat (only when active
-               * or non-current to keep the list quiet by default) */}
+              {/* Secondary row — version + heartbeat (only when active,
+               * offline, or non-current to keep the list quiet by
+               * default). The heartbeat rides along for the active tab
+               * (touch users never see the title tooltip) and for any
+               * offline row, so a dead panel's staleness is visible
+               * without selecting it. Below lg the row only survives on
+               * the active chip — the horizontal strip stays compact. */}
               <VersionTag
                 version={p.driver_version}
                 state={versionState}
                 indent
-                show={active || versionState !== "current"}
+                show={active || offline || versionState !== "current"}
+                heartbeat={
+                  active || offline ? relativeTime(p.last_seen, now) : null
+                }
+                className={active ? "flex" : "hidden lg:flex"}
               />
             </button>
           );
@@ -325,19 +336,27 @@ function VersionTag({
   state,
   indent,
   show,
+  heartbeat,
+  className,
 }: {
   version: string | null;
   state: VersionState;
   indent: boolean;
   show: boolean;
+  /** Relative heartbeat ("12s ago") appended after the version. */
+  heartbeat?: string | null;
+  className?: string;
 }) {
   if (!show) return null;
+  // Full-strength tokens only — the alpha-modified variants this row
+  // used to carry (/80, /60) landed below AA at 9px on the dark
+  // surface.
   const tone: Record<VersionState, string> = {
     current: "text-(--color-text-faint)",
-    stale: "text-(--color-danger)/80",
-    dirty: "text-(--color-amber)/80",
-    legacy: "text-(--color-amber)/80",
-    unreported: "text-(--color-text-faint)/60",
+    stale: "text-(--color-danger)",
+    dirty: "text-(--color-amber)",
+    legacy: "text-(--color-amber)",
+    unreported: "text-(--color-text-faint)",
   };
   const label: Record<VersionState, string> = {
     current: "v",
@@ -350,15 +369,21 @@ function VersionTag({
   return (
     <span
       className={[
-        "flex items-baseline gap-1.5 font-mono text-[9px] uppercase tracking-[0.2em]",
+        "items-baseline gap-1.5 font-mono text-[9px] uppercase tracking-[0.2em]",
         indent ? "pl-7" : "",
         tone[state],
+        className ?? "flex",
       ].join(" ")}
     >
       <span>{label[state]}</span>
       <span className="truncate normal-case tabular-nums">
         {version ? version.slice(0, 12) : "no report"}
       </span>
+      {heartbeat ? (
+        <span className="shrink-0 normal-case text-(--color-text-faint) tabular-nums">
+          · {heartbeat}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/dash/src/app/components/SectionPlate.tsx
+++ b/dash/src/app/components/SectionPlate.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { FOCUS_RING } from "./ui";
+
+/** Shared cell surface. Each plate cell paints its own background so
+ * the container's `gap-px` over a border-colored backdrop renders
+ * hairline dividers on BOTH axes when the plate wraps — per-cell side
+ * borders left wrapped rows borderless and doubled the container
+ * edge. (Same scheme ModeSwitcher uses for its tile grid.) */
+const CELL_BG = "bg-gradient-to-b from-(--color-surface-2) to-(--color-surface)";
+
+/**
+ * Section header plate — the "instrument label" bar that titles the
+ * simulator and queue sections. Left tag cell (`:: title / subtitle`),
+ * flex spacer, then right-side cells/buttons passed as children.
+ * Wraps cleanly: on narrow viewports trailing cells fall to a second
+ * hairline-divided row instead of overflowing.
+ */
+export function SectionPlate({
+  title,
+  subtitle,
+  children,
+  className,
+}: {
+  title: string;
+  subtitle?: string;
+  /** Right-side cells — compose from PlateCell / PlateButton. */
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={[
+        "flex flex-wrap gap-px border border-(--color-border) bg-(--color-border)",
+        className ?? "",
+      ].join(" ")}
+    >
+      <div
+        className={`flex min-w-0 items-center gap-2 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.3em] ${CELL_BG}`}
+      >
+        <span className="text-(--color-accent)">::</span>
+        <span className="text-(--color-text)">{title}</span>
+        {subtitle ? (
+          <>
+            <span className="text-(--color-text-faint)">/</span>
+            <span className="min-w-0 truncate text-(--color-text-muted)">
+              {subtitle}
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      <span aria-hidden className={`min-w-2 flex-1 ${CELL_BG}`} />
+
+      {children}
+    </div>
+  );
+}
+
+/** Passive cell on the right side of a SectionPlate. */
+export function PlateCell({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={[
+        "flex items-center gap-2 px-3 py-1.5",
+        "font-mono text-[9px] uppercase tracking-[0.3em] text-(--color-text-faint)",
+        CELL_BG,
+        className ?? "",
+      ].join(" ")}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Interactive transport chip in a SectionPlate (pause/live, off/on).
+ * Tone classes come from the caller; the base chrome and focus ring
+ * stay canonical here.
+ */
+export function PlateButton({
+  onClick,
+  ariaLabel,
+  title,
+  tone,
+  children,
+}: {
+  onClick: () => void;
+  ariaLabel: string;
+  title?: string;
+  /** Text/hover tone classes, e.g. "text-(--color-phosphor) hover:bg-…". */
+  tone: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      title={title}
+      className={[
+        "flex items-center gap-2 px-3 py-1.5",
+        "text-[10px] uppercase tracking-[0.3em] transition-colors active:brightness-90",
+        // Solid color (not the gradient): hover tones swap
+        // background-color, which a background-image gradient would
+        // paint straight over.
+        "bg-(--color-surface-2)",
+        FOCUS_RING,
+        "focus-visible:ring-inset",
+        tone,
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  );
+}

--- a/dash/src/app/components/SegmentedToggle.tsx
+++ b/dash/src/app/components/SegmentedToggle.tsx
@@ -96,7 +96,7 @@ export function SegmentedToggle<T extends string>({
               "px-3 py-1 font-mono text-[10px] uppercase tracking-[0.3em] transition-colors",
               "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
               active
-                ? "bg-(--color-accent) text-black"
+                ? "bg-(--color-accent) text-(--color-bg)"
                 : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
             ].join(" ")}
           >

--- a/dash/src/app/components/SolidColorPicker.tsx
+++ b/dash/src/app/components/SolidColorPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { FOCUS_RING } from "@/app/components/ui";
 import { hexToRgb, rgbToHex, type Rgb } from "@/utils/color";
 
 /** Preset swatches wired to the `--color-swatch-*` tokens (globals.css)
@@ -41,11 +42,40 @@ export function SolidColorPicker({
 }) {
   const valueHex = rgbToHex(value);
   const [draft, setDraft] = useState(valueHex);
+  // Native-picker draft: browsers fire `input` continuously while the
+  // user drags inside the OS color dialog. Committing each of those to
+  // the parent would ship one write per drag-frame (paint mode
+  // persists a full bitmap per commit), so the dialog edits a local
+  // draft and we commit once on the native `change` event — which
+  // fires when the dialog is dismissed.
+  const [pickerDraft, setPickerDraft] = useState(valueHex);
   const [snapshot, setSnapshot] = useState(valueHex);
   if (snapshot !== valueHex) {
     setSnapshot(valueHex);
     setDraft(valueHex);
+    setPickerDraft(valueHex);
   }
+
+  const pickerRef = useRef<HTMLInputElement>(null);
+  // Latest-callback ref so the one-time native listener below never
+  // closes over a stale onChange. (Synced in an effect — ref writes
+  // don't belong in the render body.)
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+  useEffect(() => {
+    const el = pickerRef.current;
+    if (!el) return;
+    // React's onChange maps to `input`; the dismissal-commit semantics
+    // live on the native `change` event, so wire it directly.
+    const commit = () => {
+      const rgb = hexToRgb(el.value);
+      if (rgb) onChangeRef.current(rgb);
+    };
+    el.addEventListener("change", commit);
+    return () => el.removeEventListener("change", commit);
+  }, []);
 
   // Commit the draft if it's a complete, parseable hex; otherwise
   // snap the draft back to the committed value so the field never
@@ -62,14 +92,29 @@ export function SolidColorPicker({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <span
-          className="inline-block h-5 w-5 shrink-0 border border-(--color-border-strong)"
-          style={{
-            backgroundColor: valueHex,
-            boxShadow: `0 0 10px -2px ${valueHex}`,
-          }}
-          aria-hidden
-        />
+        {/* The swatch doubles as the native color-picker trigger — the
+         * only practical color entry on mobile, where typing hex into
+         * a caps-tracked field is miserable. The input is sr-only, so
+         * its keyboard focus is surfaced on the label via focus-within
+         * (otherwise tabbing here is an invisible stop). */}
+        <label className="cursor-pointer focus-within:ring-1 focus-within:ring-(--color-accent) focus-within:ring-offset-1 focus-within:ring-offset-(--color-bg)">
+          <span
+            className="inline-block h-5 w-5 shrink-0 border border-(--color-border-strong)"
+            style={{
+              backgroundColor: pickerDraft,
+              boxShadow: `0 0 10px -2px ${pickerDraft}`,
+            }}
+            aria-hidden
+          />
+          <input
+            ref={pickerRef}
+            type="color"
+            value={pickerDraft}
+            onChange={(e) => setPickerDraft(e.target.value)}
+            className="sr-only"
+            aria-label="Open color picker"
+          />
+        </label>
         <input
           type="text"
           value={draft}
@@ -82,6 +127,9 @@ export function SolidColorPicker({
             }
           }}
           spellCheck={false}
+          autoCapitalize="characters"
+          autoComplete="off"
+          inputMode="text"
           className="flex-1 border-0 border-b border-(--color-border-strong) bg-transparent p-0 pb-0.5 font-mono text-sm uppercase tracking-wider text-(--color-text) focus:border-(--color-accent) focus:outline-none focus:ring-0"
           placeholder="#RRGGBB"
           maxLength={7}
@@ -93,7 +141,9 @@ export function SolidColorPicker({
         </span>
       </div>
 
-      <div className="flex flex-wrap gap-1">
+      {/* Buttons are 24×24 hit areas around 16px painted squares —
+       * the packed-16px grid guaranteed mis-taps on touch. */}
+      <div className="flex flex-wrap gap-1.5">
         {PRESETS.map((preset) => {
           const rgb = hexToRgb(preset.hex);
           if (!rgb) return null;
@@ -104,23 +154,24 @@ export function SolidColorPicker({
               key={preset.token}
               type="button"
               onClick={() => onChange(rgb)}
-              className={[
-                "relative h-4 w-4 border transition",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)",
-                active
-                  ? "border-(--color-text)"
-                  : "border-(--color-border) hover:border-(--color-border-strong)",
-              ].join(" ")}
-              style={{ backgroundColor: `var(${preset.token})` }}
+              className={`group flex h-6 w-6 items-center justify-center ${FOCUS_RING}`}
               title={`${preset.label} ${preset.hex}`}
               aria-label={`Pick ${preset.label}`}
             >
-              {active ? (
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 ring-1 ring-(--color-text)/60"
-                />
-              ) : null}
+              <span
+                aria-hidden
+                className={[
+                  "relative block h-4 w-4 border transition",
+                  active
+                    ? "border-(--color-text)"
+                    : "border-(--color-border) group-hover:border-(--color-border-strong)",
+                ].join(" ")}
+                style={{ backgroundColor: `var(${preset.token})` }}
+              >
+                {active ? (
+                  <span className="pointer-events-none absolute inset-0 ring-1 ring-(--color-text)/60" />
+                ) : null}
+              </span>
             </button>
           );
         })}

--- a/dash/src/app/components/StatusBar.tsx
+++ b/dash/src/app/components/StatusBar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { Lamp, PixelValue } from "@/app/components/ui";
 import { entries } from "@/utils/actions";
+import { pad } from "@/utils/format";
 import { isOffline, relativeTime } from "@/utils/offline";
 
 /**
@@ -17,6 +19,7 @@ export function StatusBar({
   panelMode,
   driverVersion,
   isPanelPaused,
+  isPanelOff,
   lastSeen,
   panelId,
   now,
@@ -25,6 +28,7 @@ export function StatusBar({
   panelMode: string | null;
   driverVersion: string | null;
   isPanelPaused: boolean;
+  isPanelOff: boolean;
   lastSeen: string | null;
   panelId: string;
   now: number;
@@ -34,28 +38,37 @@ export function StatusBar({
   const versionShort = driverVersion ? driverVersion.slice(0, 10) : "—";
 
   // Each state carries a non-color glyph in addition to its hue and
-  // the (optional) animated lamp, so paused/offline/transmitting stay
-  // distinguishable for color-blind users and when the lamp is off.
-  const beat = isPanelPaused
+  // the (optional) animated lamp, so off/paused/offline/transmitting
+  // stay distinguishable for color-blind users and when the lamp is
+  // off. Precedence mirrors the switcher lamps: offline (liveness
+  // truth-check) → off → paused → transmitting.
+  const beat = offline
     ? {
-        label: "paused",
-        glyph: "⏸",
-        tone: "text-(--color-amber)",
-        lampClass: "",
+        label: "offline",
+        glyph: "✕",
+        tone: "text-(--color-danger)",
+        lamp: false,
       }
-    : offline
+    : isPanelOff
       ? {
-          label: "offline",
-          glyph: "✕",
-          tone: "text-(--color-danger)",
-          lampClass: "",
+          label: "off",
+          glyph: "⏻",
+          tone: "text-(--color-text-faint)",
+          lamp: false,
         }
-      : {
-          label: "transmitting",
-          glyph: "●",
-          tone: "text-(--color-phosphor)",
-          lampClass: "animate-pulse bg-(--color-phosphor)",
-        };
+      : isPanelPaused
+        ? {
+            label: "paused",
+            glyph: "⏸",
+            tone: "text-(--color-amber)",
+            lamp: false,
+          }
+        : {
+            label: "transmitting",
+            glyph: "●",
+            tone: "text-(--color-phosphor)",
+            lamp: true,
+          };
 
   return (
     <footer
@@ -84,27 +97,20 @@ export function StatusBar({
             </span>
           }
           suffix={
-            beat.lampClass ? (
-              <span
-                aria-hidden
-                className={`ml-1.5 inline-block h-1.5 w-1.5 rounded-full ${beat.lampClass}`}
-              />
+            beat.lamp ? (
+              <Lamp tone="phosphor" pulse className="ml-1.5" />
             ) : null
           }
         />
-        {/* Tier 2: hide on small viewports */}
+        {/* Tier 2: hide on small viewports. The heartbeat stays at
+          * all sizes — on phones it's the only liveness readout. */}
         <Cell
           label="queue"
           value={pad(queueDepth)}
           className="hidden md:flex"
           mono
         />
-        <Cell
-          label="last seen"
-          value={relativeTime(lastSeen, now)}
-          className="hidden md:flex"
-          muted
-        />
+        <Cell label="last seen" value={relativeTime(lastSeen, now)} muted />
         <Cell
           label="driver"
           value={versionShort}
@@ -161,29 +167,24 @@ function Cell({
       </span>
       <span
         className={[
-          "flex items-center min-w-0 truncate leading-none tabular-nums",
+          "flex min-w-0 items-center truncate leading-none",
           accent
             ? "text-(--color-accent) uppercase"
             : muted
               ? "text-(--color-text-muted)"
               : valueClass ?? "text-(--color-text)",
         ].join(" ")}
-        style={
-          mono || muted
-            ? {
-                fontFamily: "var(--font-mono)",
-                fontSize: 11,
-                letterSpacing: "0.05em",
-              }
-            : {
-                fontFamily: "var(--font-pixel)",
-                fontSize: 14,
-                letterSpacing: "0.02em",
-              }
-        }
       >
         {prefix}
-        <span className="truncate">{value}</span>
+        {mono || muted ? (
+          <span className="truncate font-mono text-[11px] tracking-[0.05em] tabular-nums">
+            {value}
+          </span>
+        ) : (
+          <PixelValue size="md" className="truncate tracking-[0.02em]">
+            {value}
+          </PixelValue>
+        )}
         {suffix}
       </span>
     </div>
@@ -193,8 +194,4 @@ function Cell({
 function useQueueDepth(panelId: string) {
   const { data } = entries.get.useSWR(panelId);
   return data?.entries.length ?? 0;
-}
-
-function pad(n: number) {
-  return String(n).padStart(2, "0");
 }

--- a/dash/src/app/components/UploadRow.tsx
+++ b/dash/src/app/components/UploadRow.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useRef } from "react";
+
+import { FOCUS_RING, MicroLabel } from "./ui";
+
+/**
+ * Shared upload control for the image / gif composers: `:: upload`
+ * label, accent choose-file button, hidden input, filename/status
+ * readout. The two scenes previously duplicated this verbatim
+ * (including an accidental mb-7).
+ */
+export function UploadRow({
+  accept,
+  idleLabel,
+  busyLabel,
+  busy,
+  status,
+  onFile,
+}: {
+  accept: string;
+  idleLabel: string;
+  /** Label while `busy` — e.g. "decoding…" / "transmitting…". */
+  busyLabel: string;
+  busy: boolean;
+  /** Right-side readout: filename · dims, or the empty-state text. */
+  status: string;
+  onFile: (file: File) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div>
+      <div className="mb-3">
+        <MicroLabel>upload</MicroLabel>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={busy}
+          aria-busy={busy}
+          className={[
+            "border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-2",
+            "font-mono text-xs uppercase tracking-[0.3em] text-(--color-accent)",
+            "transition hover:bg-(--color-accent)/20 disabled:cursor-not-allowed disabled:opacity-50",
+            FOCUS_RING,
+          ].join(" ")}
+        >
+          {busy ? busyLabel : idleLabel}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={accept}
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) onFile(file);
+            e.target.value = "";
+          }}
+        />
+        <span
+          role="status"
+          className="min-w-0 truncate font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)"
+        >
+          {status}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/dash/src/app/components/ui.tsx
+++ b/dash/src/app/components/ui.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Shared instrument-language primitives. These encode the recipes
+ * that were previously copy-pasted (and drifting) across the app:
+ * the `:: label` micro-label, the VT323 pixel readout, the square
+ * status lamp, the danger banner, the empty/overlay state block, and
+ * the canonical focus ring.
+ */
+
+/** Canonical focus treatment for interactive chrome. Append
+ * `focus-visible:ring-inset` when the element sits flush in a group. */
+export const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)";
+
+/** The `:: label` micro-label classes, for places that need the raw
+ * recipe (e.g. as a <label htmlFor>). Prefer <MicroLabel>. */
+export const MICRO_LABEL_CLASS =
+  "font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)";
+
+/**
+ * Uppercase tracked micro-label with the `::` sigil — the one section
+ * label of the design language (the stray `//` variant is retired).
+ */
+export function MicroLabel({
+  children,
+  as: Tag = "span",
+  htmlFor,
+  sigil = true,
+  className,
+}: {
+  children: React.ReactNode;
+  as?: "span" | "label" | "div";
+  htmlFor?: string;
+  /** Set false for inline uses where the `::` would be noise. */
+  sigil?: boolean;
+  className?: string;
+}) {
+  return (
+    <Tag
+      htmlFor={htmlFor}
+      className={`${MICRO_LABEL_CLASS} ${className ?? ""}`}
+    >
+      {sigil ? ":: " : null}
+      {children}
+    </Tag>
+  );
+}
+
+const PIXEL_SIZE = {
+  sm: "text-[12px]",
+  md: "text-[14px]",
+  lg: "text-[16px]",
+  xl: "text-2xl",
+} as const;
+
+/**
+ * VT323 numeric/glyph readout. Replaces the 19 ad-hoc
+ * `style={{ fontFamily: "var(--font-pixel)" }}` call sites; sizes
+ * collapse to three roles — sm: chip glyphs, md: standard readout,
+ * lg: telemetry value, xl: the header wordmark.
+ */
+export function PixelValue({
+  size = "md",
+  className,
+  children,
+}: {
+  size?: keyof typeof PIXEL_SIZE;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={`font-pixel leading-none tabular-nums ${PIXEL_SIZE[size]} ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export type LampTone = "phosphor" | "accent" | "amber" | "danger" | "faint";
+
+const LAMP_TONE: Record<LampTone, { bg: string; glow: string | null }> = {
+  phosphor: { bg: "bg-(--color-phosphor)", glow: "var(--color-phosphor)" },
+  accent: { bg: "bg-(--color-accent)", glow: "var(--color-accent)" },
+  amber: { bg: "bg-(--color-amber)", glow: "var(--color-amber)" },
+  danger: { bg: "bg-(--color-danger)", glow: "var(--color-danger)" },
+  faint: { bg: "bg-(--color-text-faint)", glow: null },
+};
+
+/**
+ * Square status lamp — the deliberate instrument-panel cue (LED
+ * package, not a web dot). One geometry everywhere; previously split
+ * between rounded-full and rounded-[1px] copies.
+ */
+export function Lamp({
+  tone,
+  pulse = false,
+  glow = true,
+  className,
+}: {
+  tone: LampTone;
+  pulse?: boolean;
+  /** Render the colored halo (skip for quiet/inactive lamps). */
+  glow?: boolean;
+  className?: string;
+}) {
+  const t = LAMP_TONE[tone];
+  return (
+    <span
+      aria-hidden
+      className={[
+        "inline-block h-1.5 w-1.5 shrink-0 rounded-[1px]",
+        t.bg,
+        pulse ? "animate-pulse" : "",
+        className ?? "",
+      ].join(" ")}
+      style={glow && t.glow ? { boxShadow: `0 0 6px ${t.glow}` } : undefined}
+    />
+  );
+}
+
+/**
+ * Canonical danger banner. role="alert" is built in so async failures
+ * (transmit, decode, reorder) are announced — three of the six
+ * previous hand-rolled copies forgot it.
+ */
+export function Alert({
+  children,
+  center = false,
+  className,
+}: {
+  children: React.ReactNode;
+  center?: boolean;
+  className?: string;
+}) {
+  return (
+    <p
+      role="alert"
+      className={[
+        "border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-2",
+        "font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)",
+        center ? "text-center" : "",
+        className ?? "",
+      ].join(" ")}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Stacked title + detail state block. `block` is the bordered
+ * empty-state card, `overlay` floats over the simulator, `dashed` is
+ * the compact side-rail variant.
+ */
+export function EmptyState({
+  title,
+  detail,
+  variant = "block",
+  tone = "default",
+  className,
+}: {
+  title: string;
+  detail?: string;
+  variant?: "block" | "overlay" | "dashed";
+  /** `danger` renders the title in the danger tone (offline states). */
+  tone?: "default" | "danger";
+  className?: string;
+}) {
+  const chrome = {
+    block:
+      "flex flex-col items-center gap-2 border border-dashed border-(--color-border) bg-(--color-surface)/40 px-4 py-10 text-center",
+    overlay:
+      "pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 text-center backdrop-blur-[1px]",
+    dashed:
+      "flex flex-col items-center gap-1 border border-dashed border-(--color-border) px-2 py-3 text-center",
+  }[variant];
+  const titleSize = variant === "overlay" ? "text-[11px]" : "text-[10px]";
+  const titleTone =
+    tone === "danger" ? "text-(--color-danger)" : "text-(--color-text-dim)";
+
+  return (
+    <div className={`${chrome} font-mono uppercase ${className ?? ""}`}>
+      <p className={`${titleSize} tracking-[0.3em] ${titleTone}`}>{title}</p>
+      {detail ? (
+        <p className="text-[9px] tracking-[0.25em] text-(--color-text-faint)">
+          {detail}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/dash/src/app/components/useRovingRadio.ts
+++ b/dash/src/app/components/useRovingRadio.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useRef } from "react";
+
+/**
+ * Roving-tabindex keyboard model for a `role="radiogroup"` of
+ * arbitrary tiles — the same contract SegmentedToggle implements for
+ * text pills, shared so the glyph/icon tile groups (paint tools,
+ * shape picker, test patterns) stop advertising radio semantics they
+ * don't honor.
+ *
+ * Usage:
+ *   const radio = useRovingRadio(ids, value, onChange);
+ *   <div role="radiogroup" aria-label=… onKeyDown={radio.onKeyDown}>
+ *     {options.map((o, i) => (
+ *       <button {...radio.itemProps(o.id, i)} …visuals… />
+ *     ))}
+ *   </div>
+ *
+ * Arrow keys move + select the neighbour (selection follows focus,
+ * the standard radio model); Home/End jump to the ends. Only the
+ * checked tile sits in the Tab order.
+ */
+export function useRovingRadio<T extends string>(
+  ids: readonly T[],
+  value: T,
+  onChange: (next: T) => void,
+) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const select = (index: number) => {
+    const id = ids[index];
+    if (id === undefined) return;
+    onChange(id);
+    refs.current[index]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const current = Math.max(0, ids.indexOf(value));
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        e.preventDefault();
+        select((current + 1) % ids.length);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        e.preventDefault();
+        select((current - 1 + ids.length) % ids.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        select(0);
+        break;
+      case "End":
+        e.preventDefault();
+        select(ids.length - 1);
+        break;
+    }
+  };
+
+  const itemProps = (id: T, index: number) => ({
+    ref: (el: HTMLButtonElement | null) => {
+      refs.current[index] = el;
+    },
+    type: "button" as const,
+    role: "radio" as const,
+    "aria-checked": id === value,
+    tabIndex: id === value ? 0 : -1,
+    onClick: () => onChange(id),
+  });
+
+  return { onKeyDown, itemProps };
+}

--- a/dash/src/app/page.tsx
+++ b/dash/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PowerIcon } from "@heroicons/react/24/outline";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { BrightnessControl } from "@/app/components/BrightnessControl";
 import { Composer } from "@/app/components/Composer";
@@ -13,16 +13,22 @@ import {
 } from "@/app/components/EffectsPanel";
 import { EntriesList } from "@/app/components/EntriesList";
 import { InstrumentHeader } from "@/app/components/InstrumentHeader";
-import { MatrixPreview } from "@/app/components/MatrixPreview";
+import { MatrixFrame, MatrixPreview } from "@/app/components/MatrixPreview";
 import {
   PANEL_CONTENT_ID,
   PanelSwitcher,
 } from "@/app/components/PanelSwitcher";
+import {
+  PlateButton,
+  PlateCell,
+  SectionPlate,
+} from "@/app/components/SectionPlate";
 import { StatusBar } from "@/app/components/StatusBar";
+import { Lamp, PixelValue } from "@/app/components/ui";
 import { PanelContext } from "@/app/context";
 import { SCENES } from "@/app/scenes";
 import { parseLifeConfig, useLifeScene } from "@/app/scenes/life";
-import { ModeSwitcher } from "@/app/scenes/ModeSwitcher";
+import { MODE_CONTENT_ID, ModeSwitcher } from "@/app/scenes/ModeSwitcher";
 import { MODES } from "@/app/scenes/types";
 import {
   entries,
@@ -33,12 +39,17 @@ import {
 import { LED_ORANGE } from "@/utils/color";
 import { isOffline, relativeTime } from "@/utils/offline";
 import { useNow } from "@/utils/useNow";
+import { useReducedMotion } from "@/utils/useReducedMotion";
 
+/** Marquee speed applied when a long payload force-enables the
+ * marquee while the user has it at 0. EffectsPanel's
+ * `autoForcedSpeed` default mirrors this so display and wire value
+ * can't diverge. */
 const AUTO_FORCED_DEFAULT = 10;
 
 export default function Page() {
   const realtimeStatus = useRealtimeRevalidation();
-  const { data: panelsData } = panels.get.useSWR();
+  const { data: panelsData, isLoading: panelsLoading } = panels.get.useSWR();
 
   const [chosenPanelId, setChosenPanelId] = useState<string | null>(null);
   const defaultPanelId = useMemo(() => {
@@ -83,15 +94,23 @@ export default function Page() {
   const [effects, setEffects] = useState<EffectsState>({ marqueeSpeed: 0 });
   const [submitError, setSubmitError] = useState(false);
 
-  // Switching panels starts a fresh composition. Reset composer effects
-  // (so one panel's auto-forced marquee doesn't bleed into the next) and
-  // clear any stale transmit-failure flag — done during render via the
-  // documented "adjust state when a prop changes" pattern (matches the
-  // chosenPanelId reset above), keeping it out of an effect.
+  // Switching panels starts a fresh composition. Reset composer
+  // effects and clear any stale transmit-failure flag — done during
+  // render via the documented "adjust state when a prop changes"
+  // pattern (matches the chosenPanelId reset above). The reset is
+  // message-aware: a still-long payload re-applies the auto-forced
+  // marquee default immediately, which used to be handled by a pair
+  // of effects whose ordering left the state at 0-while-forced (UI
+  // showed 01, the wire carried 10).
   const [effectsPanelId, setEffectsPanelId] = useState(panelId);
   if (effectsPanelId !== panelId) {
     setEffectsPanelId(panelId);
-    setEffects({ marqueeSpeed: 0 });
+    setEffects({
+      marqueeSpeed:
+        message.length >= FORCE_ENABLE_MARQUEE_LENGTH
+          ? AUTO_FORCED_DEFAULT
+          : 0,
+    });
     setSubmitError(false);
   }
 
@@ -99,22 +118,8 @@ export default function Page() {
     activeMode === "text" && message.length > 0 && panelId.length > 0;
   const isMarqueeForced = message.length >= FORCE_ENABLE_MARQUEE_LENGTH;
 
-  const wasForced = useRef(false);
-
-  useEffect(() => {
-    if (isMarqueeForced && !wasForced.current && effects.marqueeSpeed === 0) {
-      setEffects((e) => ({ ...e, marqueeSpeed: AUTO_FORCED_DEFAULT }));
-    }
-    wasForced.current = isMarqueeForced;
-  }, [isMarqueeForced, effects.marqueeSpeed]);
-
-  // Clear the auto-force latch when the panel changes so the next
-  // panel's first long message re-applies the default marquee speed.
-  // (Ref writes belong in an effect, not in render.)
-  useEffect(() => {
-    wasForced.current = false;
-  }, [panelId]);
-
+  // A long payload with the slider at 0 transmits at the auto-forced
+  // default; EffectsPanel displays the same value via autoForcedSpeed.
   const effectiveMarqueeSpeed =
     isMarqueeForced && effects.marqueeSpeed === 0
       ? AUTO_FORCED_DEFAULT
@@ -160,14 +165,25 @@ export default function Page() {
   );
 
   // Life mode owns its own animation loop (rAF-driven cellular tick).
-  // Always running so previewing is instant when the user switches
-  // in. Bypasses the SCENES registry's erased types — this is the
-  // one consumer that needs the life-typed config directly.
+  // Bypasses the SCENES registry's erased types — this is the one
+  // consumer that needs the life-typed config directly. The ticker
+  // must gate on reduced-motion and paused/off itself: each
+  // generation's new cells array would otherwise push a fresh scene
+  // through MatrixPreview's idle-wake path and animate right past the
+  // preview's own motion gates.
+  const reducedMotion = useReducedMotion();
   const lifeConfig = useMemo(
     () => parseLifeConfig(activePanel?.mode_config),
     [activePanel?.mode_config],
   );
-  const lifeScene = useLifeScene(lifeConfig, activeMode === "life");
+  const lifeScene = useLifeScene(
+    lifeConfig,
+    activeMode === "life" &&
+      !reducedMotion &&
+      !activePanelOffline &&
+      !(activePanel?.is_paused ?? false) &&
+      !(activePanel?.is_off ?? false),
+  );
 
   // Build the Scene the simulator renders. Clock mode samples
   // `now` internally, so its memo needs to re-run each tick — but
@@ -202,33 +218,29 @@ export default function Page() {
       <InstrumentHeader realtimeStatus={realtimeStatus} />
       <div className="mx-auto flex min-h-dvh max-w-6xl flex-col gap-5 px-4 pt-5 pb-12 sm:px-6 lg:px-10">
         {/* ─── instrument: matrix simulator ──────────────────────── */}
-        {/* This section is the tabpanel the PanelSwitcher tabs drive
-          * (each tab's aria-controls points at PANEL_CONTENT_ID). When a
-          * panel is selected we label it by its tab; otherwise a static
-          * label so AT still announces the region. */}
-        <section
-          id={PANEL_CONTENT_ID}
-          role="tabpanel"
-          aria-label={hasPanels && panelId ? undefined : "Live simulator"}
-          aria-labelledby={
-            hasPanels && panelId ? `panel-tab-${panelId}` : undefined
-          }
-          className="grid gap-4 lg:grid-cols-[1fr_240px]"
-        >
-          <div className="relative">
+        <section className="grid gap-4 lg:grid-cols-[1fr_240px]">
+          {/* This div is the tabpanel the PanelSwitcher tabs drive
+            * (each tab's aria-controls points at PANEL_CONTENT_ID). It
+            * deliberately excludes the <aside> holding the tablist —
+            * a tabpanel containing its own tabs is a circular ARIA
+            * relationship. When a panel is selected we label it by its
+            * tab; otherwise a static label so AT still announces the
+            * region. */}
+          <div
+            id={PANEL_CONTENT_ID}
+            role="tabpanel"
+            aria-label={hasPanels && panelId ? undefined : "Live simulator"}
+            aria-labelledby={
+              hasPanels && panelId ? `panel-tab-${panelId}` : undefined
+            }
+            className="relative"
+          >
             {/* Section heading plate — instrument-label feel */}
-            <div className="mb-3 flex items-stretch border border-(--color-border) bg-gradient-to-b from-(--color-surface-2)/60 to-(--color-surface)/40">
-              <div className="flex items-center gap-2 border-r border-(--color-border) px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.3em]">
-                <span className="text-(--color-accent)">::</span>
-                <span className="text-(--color-text)">simulator</span>
-                <span className="text-(--color-text-faint)">/</span>
-                <span className="text-(--color-text-muted)">
-                  wasm · driver-core
-                </span>
-              </div>
-
-              <span aria-hidden className="flex-1" />
-
+            <SectionPlate
+              title="simulator"
+              subtitle="wasm · driver-core"
+              className="mb-3"
+            >
               {/* Global brightness fader — final multiply, alongside
                 * the pause/off transport. */}
               {panelId.length > 0 ? (
@@ -241,46 +253,34 @@ export default function Page() {
 
               {/* Pause / Live transport button */}
               {panelId.length > 0 ? (
-                <button
-                  type="button"
+                <PlateButton
                   onClick={() =>
                     void panels.setPaused.call(
                       panelId,
                       !(activePanel?.is_paused ?? false),
                     )
                   }
-                  aria-label={
+                  ariaLabel={
                     activePanel?.is_paused ? "Resume panel" : "Pause panel"
                   }
                   title={`last seen ${relativeTime(activePanel?.last_seen, now)} · click to ${activePanel?.is_paused ? "resume" : "pause"}`}
-                  className={[
-                    "flex items-center gap-2 border-l border-(--color-border) bg-(--color-surface-2)/60 px-3 py-1.5 text-[10px] uppercase tracking-[0.3em] transition-colors active:brightness-90",
+                  tone={
                     activePanel?.is_paused
                       ? "text-(--color-accent) hover:bg-(--color-accent)/20"
                       : activePanelOffline
                         ? "text-(--color-danger) hover:bg-(--color-surface-3)"
-                        : "text-(--color-phosphor) hover:bg-(--color-surface-3)",
-                  ].join(" ")}
+                        : "text-(--color-phosphor) hover:bg-(--color-surface-3)"
+                  }
                 >
-                  <span
-                    aria-hidden
-                    className={
-                      activePanel?.is_paused || activePanelOffline
-                        ? ""
-                        : "h-1.5 w-1.5 animate-pulse rounded-full bg-(--color-phosphor)"
-                    }
-                    style={
-                      activePanel?.is_paused || activePanelOffline
-                        ? { fontFamily: "var(--font-pixel)", fontSize: 12 }
-                        : undefined
-                    }
-                  >
-                    {activePanel?.is_paused
-                      ? "▶"
-                      : activePanelOffline
-                        ? "✕"
-                        : ""}
-                  </span>
+                  {activePanel?.is_paused || activePanelOffline ? (
+                    <span aria-hidden>
+                      <PixelValue size="sm">
+                        {activePanel?.is_paused ? "▶" : "✕"}
+                      </PixelValue>
+                    </span>
+                  ) : (
+                    <Lamp tone="phosphor" pulse glow={false} />
+                  )}
                   <span>
                     {activePanel?.is_paused
                       ? "paused"
@@ -288,58 +288,55 @@ export default function Page() {
                         ? "offline"
                         : "live"}
                   </span>
-                </button>
+                </PlateButton>
               ) : null}
 
               {/* Off / On hardware-power transport. Composes with
                 * pause: "off" short-circuits the driver to a black
                 * frame without losing the panel's mode/config or
-                * queued entries — flip back to resume the same
-                * scene. */}
+                * queued entries — flip back to resume the same scene.
+                * The consequence lives in the accessible name, not
+                * just the title (tooltips don't exist on touch). */}
               {panelId.length > 0 ? (
-                <button
-                  type="button"
+                <PlateButton
                   onClick={() =>
                     void panels.setOff.call(
                       panelId,
                       !(activePanel?.is_off ?? false),
                     )
                   }
-                  aria-label={
-                    activePanel?.is_off ? "Turn panel on" : "Turn panel off"
+                  ariaLabel={
+                    activePanel?.is_off
+                      ? "Turn panel on — resumes the current mode"
+                      : "Turn panel off — mode and queue preserved"
                   }
                   title={
                     activePanel?.is_off
                       ? "click to turn on (resumes current mode)"
                       : "click to turn off (panel goes dark; mode + queue preserved)"
                   }
-                  className={[
-                    "flex items-center gap-2 border-l border-(--color-border) bg-(--color-surface-2)/60 px-3 py-1.5 text-[10px] uppercase tracking-[0.3em] transition-colors active:brightness-90",
+                  tone={
                     activePanel?.is_off
                       ? "text-(--color-danger) hover:bg-(--color-danger)/20"
                       : activePanelOffline
                         ? "text-(--color-text-faint) hover:bg-(--color-surface-3)"
-                        : "text-(--color-text-muted) hover:bg-(--color-surface-3) hover:text-(--color-text)",
-                  ].join(" ")}
+                        : "text-(--color-text-muted) hover:bg-(--color-surface-3) hover:text-(--color-text)"
+                  }
                 >
                   <PowerIcon aria-hidden className="h-3.5 w-3.5" />
                   <span>{activePanel?.is_off ? "off" : "on"}</span>
-                </button>
+                </PlateButton>
               ) : null}
 
               {/* Format chip — pixel font for the resolution */}
-              <div className="flex items-center gap-2 border-l border-(--color-border) px-3 py-1.5 font-mono text-[9px] uppercase tracking-[0.3em] text-(--color-text-faint) tabular-nums">
-                <span style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}>
-                  64×64
-                </span>
+              <PlateCell className="tabular-nums">
+                <PixelValue size="md">64×64</PixelValue>
                 <span aria-hidden className="text-(--color-border-strong)">
                   /
                 </span>
-                <span style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}>
-                  rgb888
-                </span>
-              </div>
-            </div>
+                <PixelValue size="md">rgb888</PixelValue>
+              </PlateCell>
+            </SectionPlate>
 
             <div className="relative">
               <CornerBracket pos="tl" size="lg" />
@@ -355,22 +352,41 @@ export default function Page() {
                   brightness={activePanel?.brightness ?? 1}
                 />
               ) : (
-                // No panels registered — an offline simulator here would
-                // read as a broken panel rather than an empty fleet.
-                <div className="flex aspect-square w-full flex-col items-center justify-center gap-2 rounded-2xl border border-(--color-border) bg-black text-center font-mono uppercase tracking-[0.3em]">
-                  <span className="text-[11px] text-(--color-text-dim)">
-                    no panels registered
-                  </span>
-                  <span className="text-[9px] text-(--color-text-faint)">
-                    connect a driver to begin
-                  </span>
-                </div>
+                // Same bezel as the live simulator so the frame doesn't
+                // jump when data lands. While the fleet index is still
+                // loading we say so — flashing "no panels registered"
+                // on every cold start read as a broken fleet.
+                <MatrixFrame>
+                  <div className="flex aspect-square w-full flex-col items-center justify-center gap-2 text-center font-mono uppercase tracking-[0.3em]">
+                    {panelsLoading ? (
+                      <>
+                        <span className="animate-pulse text-[11px] text-(--color-text-dim)">
+                          scanning fleet ···
+                        </span>
+                        <span className="text-[9px] text-(--color-text-faint)">
+                          awaiting first telemetry
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <span className="text-[11px] text-(--color-text-dim)">
+                          no panels registered
+                        </span>
+                        <span className="text-[9px] text-(--color-text-faint)">
+                          connect a driver to begin
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </MatrixFrame>
               )}
             </div>
           </div>
 
-          {/* Side rail: target selector */}
-          <aside className="flex flex-col gap-4">
+          {/* Side rail: target selector. Ordered above the simulator
+            * on phones — picking the target panel is the first
+            * decision of a session and used to sit below the fold. */}
+          <aside className="order-first flex flex-col gap-4 lg:order-none">
             <PanelSwitcher panelId={panelId} onChange={setChosenPanelId} />
           </aside>
         </section>
@@ -381,52 +397,67 @@ export default function Page() {
         ) : null}
 
         {/* ─── per-mode bottom half ──────────────────────────────── */}
-        {activeMode === "text" ? (
-          // Text mode is special — it pairs the composer with the live
-          // entries queue, side by side on lg+. Other modes are
-          // single-pane composers and route through SCENES[mode].Composer.
-          <div className="grid flex-1 gap-6 lg:grid-cols-[1fr_1fr]">
-            <Composer
-              message={message}
-              onMessageChange={(s) => {
-                // Editing the payload clears a stale transmit failure.
-                if (submitError) setSubmitError(false);
-                setMessage(s);
-              }}
-              color={color}
-              onColorChange={setColor}
-              effects={effects}
-              onEffectsChange={setEffects}
-              onSubmit={handleSubmit}
-              disabled={!isSubmittable}
-              transmitFailed={submitError}
+        {/* Tabpanel for the ModeSwitcher tabs (aria-controls →
+          * MODE_CONTENT_ID). Composers remount per panel:mode via the
+          * key — paint's bitmap/undo stacks, upload errors, and other
+          * instance state must not survive a target switch. */}
+        <div
+          id={MODE_CONTENT_ID}
+          role="tabpanel"
+          aria-labelledby={
+            hasPanels && panelId ? `mode-tab-${activeMode}` : undefined
+          }
+          aria-label={hasPanels && panelId ? undefined : "Composer"}
+          className="flex flex-1 flex-col"
+        >
+          {activeMode === "text" ? (
+            // Text mode is special — it pairs the composer with the live
+            // entries queue, side by side on lg+. Other modes are
+            // single-pane composers and route through SCENES[mode].Composer.
+            <div className="grid flex-1 gap-6 lg:grid-cols-[1fr_1fr]">
+              <Composer
+                key={`${panelId}:text`}
+                message={message}
+                onMessageChange={(s) => {
+                  // Editing the payload clears a stale transmit failure.
+                  if (submitError) setSubmitError(false);
+                  setMessage(s);
+                }}
+                color={color}
+                onColorChange={setColor}
+                effects={effects}
+                onEffectsChange={setEffects}
+                onSubmit={handleSubmit}
+                disabled={!isSubmittable}
+                transmitFailed={submitError}
+              />
+              <section
+                className="flex min-h-0 flex-col gap-3"
+                aria-label="Messages"
+              >
+                <SectionPlate title="queue">
+                  <PlateCell>
+                    <span>top 7 on-air · drag to reorder</span>
+                  </PlateCell>
+                </SectionPlate>
+                <EntriesList />
+              </section>
+            </div>
+          ) : (
+            <frame.Composer
+              key={`${panelId}:${activeMode}`}
+              panelId={panelId}
+              config={activeConfig}
             />
-            <section
-              className="flex min-h-0 flex-col gap-3"
-              aria-label="Messages"
-            >
-              <div className="flex items-stretch border border-(--color-border) bg-gradient-to-b from-(--color-surface-2)/60 to-(--color-surface)/40">
-                <div className="flex items-center gap-2 border-r border-(--color-border) px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.3em]">
-                  <span className="text-(--color-accent)">::</span>
-                  <span className="text-(--color-text)">queue</span>
-                </div>
-                <span aria-hidden className="flex-1" />
-                <div className="flex items-center gap-2 border-l border-(--color-border) px-3 py-1.5 font-mono text-[9px] uppercase tracking-[0.3em] text-(--color-text-faint)">
-                  <span>top 7 on-air · drag to reorder</span>
-                </div>
-              </div>
-              <EntriesList />
-            </section>
-          </div>
-        ) : (
-          <frame.Composer panelId={panelId} config={activeConfig} />
-        )}
+          )}
+        </div>
 
         <StatusBar
           panelName={activePanel?.name ?? null}
           panelMode={activeMode}
           driverVersion={activePanel?.driver_version ?? null}
           isPanelPaused={activePanel?.is_paused ?? false}
+          isPanelOff={activePanel?.is_off ?? false}
           lastSeen={activePanel?.last_seen ?? null}
           panelId={panelId}
           now={now}

--- a/dash/src/app/scenes/ModeSwitcher.tsx
+++ b/dash/src/app/scenes/ModeSwitcher.tsx
@@ -10,27 +10,36 @@ import {
   PhotoIcon,
   SparklesIcon,
 } from "@heroicons/react/24/outline";
+import { useRef, useState } from "react";
 
 import { MODES } from "./types";
 
+import { FOCUS_RING } from "@/app/components/ui";
 import { panels, type PanelMode } from "@/utils/actions";
+import { recallModeConfig, rememberModeConfig } from "@/utils/modeConfigCache";
 
 /**
- * Per-mode config cache, module-scoped so it survives this component's
- * remounts within a session. Keyed by `panelId:mode`. The DB stores a
- * single `mode_config` column shared across modes, so naively writing
- * `{}` on every switch wiped the outgoing editor's work. We instead
- * stash the outgoing mode's config here on switch and restore the
- * incoming mode's last-known config (if we've seen it), so toggling
- * modes back and forth no longer destroys the previous editor's state.
+ * The id of the content region these tabs drive — the per-mode
+ * composer section in page.tsx. Each tab's `aria-controls` points
+ * here so AT announces the tab/panel relationship. page.tsx must
+ * carry the matching `id={MODE_CONTENT_ID}` + `role="tabpanel"` +
+ * `aria-labelledby={`mode-tab-${mode}`}`.
  */
-const configCache = new Map<string, Record<string, unknown>>();
-const cacheKey = (panelId: string, mode: PanelMode) => `${panelId}:${mode}`;
+export const MODE_CONTENT_ID = "mode-content";
 
 /**
- * Segmented mode picker. Switching preserves per-mode config across
- * toggles (see `configCache`); per-mode forms still hydrate their own
- * defaults if config is missing/partial.
+ * Segmented mode picker. The DB stores a single `mode_config` column
+ * shared across modes, so naively writing `{}` on every switch wiped
+ * the outgoing editor's work. Per-mode configs survive toggles via
+ * the shared write-through cache in `@/utils/modeConfigCache`:
+ * actions.ts records every config it actually writes (setMode /
+ * setModeConfig), so the cache always holds the freshest written
+ * value — the SWR snapshot lags by debounce + write RTT +
+ * realtime-echo RTT, and restoring from it silently reverted recent
+ * edits. On switch we snapshot the server row too; the cache
+ * arbitrates by timestamp so whichever is genuinely newer wins.
+ * Per-mode forms still hydrate their own defaults if config is
+ * missing/partial.
  *
  * Each tile is a "preset key" — heroicon glyph, label, and short
  * blurb. Active tile gets a recessed/illuminated treatment; inactive
@@ -47,19 +56,73 @@ export function ModeSwitcher({
   // the page root) so we can snapshot the OUTGOING mode's config
   // before we switch away from it.
   const { data: allPanels } = panels.get.useSWR();
+  const activeRow = allPanels?.find((p) => p.id === panelId);
   const currentConfig =
-    (allPanels?.find((p) => p.id === panelId)?.mode_config as
-      | Record<string, unknown>
-      | null
-      | undefined) ?? null;
+    (activeRow?.mode_config as Record<string, unknown> | null | undefined) ??
+    null;
+
+  // Refs to each tab button, so arrow-key navigation can move DOM
+  // focus to the newly-focused tab (roving tabindex pattern).
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // ARIA tab pattern, MANUAL ACTIVATION variant: arrows move focus
+  // only; Enter/Space (the button's native click) activates. NOT
+  // selection-follows-focus — switchTo fires a Supabase write that
+  // changes the physical panel, so merely arrowing across the tiles
+  // must never activate them. `focusedId` drives the roving tabindex
+  // and resyncs to `current` whenever the selected mode changes
+  // (render-time adjust, not an effect).
+  const [focusedId, setFocusedId] = useState<PanelMode>(current);
+  const [prevCurrent, setPrevCurrent] = useState<PanelMode>(current);
+  if (prevCurrent !== current) {
+    setPrevCurrent(current);
+    setFocusedId(current);
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        next = (index + 1) % MODES.length;
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        next = (index - 1 + MODES.length) % MODES.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = MODES.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const target = MODES[next];
+    if (target) {
+      setFocusedId(target.id);
+      tabRefs.current[next]?.focus();
+    }
+  };
 
   const switchTo = (next: PanelMode) => {
-    // Snapshot what's currently persisted under the outgoing mode so a
-    // later switch back restores it rather than the empty default.
+    // Snapshot what's currently persisted under the outgoing mode.
+    // The cache compares timestamps: a write-through entry from a
+    // local write that's FRESHER than the row keeps winning (the SWR
+    // snapshot lags by debounce + RTT + echo), but a row that's NEWER
+    // than the cached entry — an MCP write, a second tab — replaces
+    // it, so switching back can't resurrect a stale config over an
+    // external writer's work.
     if (currentConfig && Object.keys(currentConfig).length > 0) {
-      configCache.set(cacheKey(panelId, current), currentConfig);
+      // Undefined falls back to "now" inside the cache helper.
+      const rowAt = activeRow?.last_updated
+        ? Date.parse(activeRow.last_updated)
+        : undefined;
+      rememberModeConfig(panelId, current, currentConfig, rowAt);
     }
-    const restored = configCache.get(cacheKey(panelId, next)) ?? {};
+    const restored = recallModeConfig(panelId, next) ?? {};
     void panels.setMode.call(panelId, next, restored);
   };
 
@@ -69,29 +132,40 @@ export function ModeSwitcher({
       aria-label="Mode"
       className="bezel-recessed relative flex flex-wrap gap-px overflow-hidden border border-(--color-border) bg-(--color-border)"
     >
-      {MODES.map((m) => {
+      {MODES.map((m, i) => {
         const active = m.id === current;
         const Icon = MODE_ICONS[m.id];
         return (
           <button
             key={m.id}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
             type="button"
             role="tab"
+            id={`mode-tab-${m.id}`}
             aria-selected={active}
+            aria-controls={MODE_CONTENT_ID}
+            tabIndex={m.id === focusedId ? 0 : -1}
+            onKeyDown={(e) => onKeyDown(e, i)}
             onClick={() => {
               if (active) return;
               switchTo(m.id);
             }}
             // Even-rows wrap: each tile takes a slightly-less-than-25%
-            // basis so a row of 4 fits exactly even with the
+            // basis (50% on phones, where 4-across crushes the labels
+            // to ellipses) so a row of 4 fits exactly even with the
             // 1px gap between tiles, and a trailing row of N<4 grows
             // each tile via flex-grow=1 to fill — 5 tiles → 4+1 (1
             // grows full-width), 6 → 4+2 (each 50%), 7 → 4+3 (each
-            // 33%). `min-w-0` lets tiles actually shrink to their
-            // basis instead of pinning to intrinsic content width
-            // (default min-width:auto would prevent that).
+            // 33%). The same math holds for the 2-across phone grid.
+            // `min-w-0` lets tiles actually shrink to their basis
+            // instead of pinning to intrinsic content width (default
+            // min-width:auto would prevent that).
             className={[
-              "group relative isolate flex min-w-0 grow items-stretch gap-3 px-4 py-3 text-left transition-all basis-[calc(25%-1px)]",
+              "group relative isolate flex min-w-0 grow items-stretch gap-2 px-3 py-3 text-left transition-all basis-[calc(50%-1px)] sm:gap-3 sm:px-4 sm:basis-[calc(25%-1px)]",
+              FOCUS_RING,
+              "focus-visible:ring-inset",
               active
                 ? "bg-(--color-bg) text-(--color-accent) shadow-[inset_0_0_24px_-4px_var(--color-accent-fade)]"
                 : "bg-(--color-surface)/70 text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",

--- a/dash/src/app/scenes/clock.tsx
+++ b/dash/src/app/scenes/clock.tsx
@@ -17,6 +17,7 @@ import {
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { ControlRow } from "@/app/components/ControlRow";
 import { SegmentedToggle } from "@/app/components/SegmentedToggle";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
 import { parseRgb } from "@/utils/color";
@@ -105,76 +106,61 @@ export function ClockComposer({
   );
 
   return (
-    <ComposerShell title="clock" status="local time" ariaLabel="Clock configuration">
-      <div className="space-y-5 px-4 py-4">
-        <Row label="format">
-          <SegmentedToggle<"H12" | "H24">
-            ariaLabel="Time format"
-            options={[
-              { id: "H24", label: "24h" },
-              { id: "H12", label: "12h" },
-            ]}
-            value={draft.format}
-            onChange={(format) => update({ ...draft, format })}
-          />
-        </Row>
-
-        <Row label="seconds">
-          <SegmentedToggle
-            ariaLabel="Show seconds"
-            options={[
-              { id: "off", label: "off" },
-              { id: "on", label: "on" },
-            ]}
-            value={draft.show_seconds ? "on" : "off"}
-            onChange={(v) => update({ ...draft, show_seconds: v === "on" })}
-          />
-        </Row>
-
-        {draft.format === "H12" ? (
-          <Row label="meridiem">
-            <SegmentedToggle
-              ariaLabel="Show meridiem"
-              options={[
-                { id: "off", label: "hidden" },
-                { id: "on", label: "a/p" },
-              ]}
-              value={draft.show_meridiem ? "on" : "off"}
-              onChange={(v) => update({ ...draft, show_meridiem: v === "on" })}
-            />
-          </Row>
-        ) : null}
-
-        <Row label="timezone">
-          <TimezoneSelect
-            value={draft.timezone}
-            onChange={(timezone) => update({ ...draft, timezone })}
-          />
-        </Row>
-
-        <SolidColorPicker
-          value={draft.color}
-          onChange={(color) => update({ ...draft, color })}
+    <ComposerShell
+      title="clock"
+      status={draft.timezone ?? "local time"}
+      ariaLabel="Clock configuration"
+    >
+      <ControlRow label="format">
+        <SegmentedToggle<"H12" | "H24">
+          ariaLabel="Time format"
+          options={[
+            { id: "H24", label: "24h" },
+            { id: "H12", label: "12h" },
+          ]}
+          value={draft.format}
+          onChange={(format) => update({ ...draft, format })}
         />
-      </div>
-    </ComposerShell>
-  );
-}
+      </ControlRow>
 
-function Row({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-        :: {label}
-      </span>
-      <div className="flex items-center">{children}</div>
-    </div>
+      <ControlRow label="seconds">
+        <SegmentedToggle
+          ariaLabel="Show seconds"
+          options={[
+            { id: "off", label: "off" },
+            { id: "on", label: "on" },
+          ]}
+          value={draft.show_seconds ? "on" : "off"}
+          onChange={(v) => update({ ...draft, show_seconds: v === "on" })}
+        />
+      </ControlRow>
+
+      {draft.format === "H12" ? (
+        <ControlRow label="meridiem">
+          <SegmentedToggle
+            ariaLabel="Show meridiem"
+            options={[
+              { id: "off", label: "hidden" },
+              { id: "on", label: "a/p" },
+            ]}
+            value={draft.show_meridiem ? "on" : "off"}
+            onChange={(v) => update({ ...draft, show_meridiem: v === "on" })}
+          />
+        </ControlRow>
+      ) : null}
+
+      <ControlRow label="timezone">
+        <TimezoneSelect
+          value={draft.timezone}
+          onChange={(timezone) => update({ ...draft, timezone })}
+        />
+      </ControlRow>
+
+      <SolidColorPicker
+        value={draft.color}
+        onChange={(color) => update({ ...draft, color })}
+      />
+    </ComposerShell>
   );
 }
 
@@ -229,14 +215,14 @@ function TimezoneSelect({
           aria-label="Timezone"
           displayValue={() => display}
           onChange={(e) => setQuery(e.target.value)}
-          className="w-full border border-(--color-border) bg-(--color-surface-2) px-2 py-1 pr-6 font-mono text-[10px] tracking-[0.1em] text-(--color-text) focus:border-(--color-accent) focus:outline-none"
+          className="w-full border border-(--color-border) bg-(--color-surface-2) px-2 py-1 pr-6 font-mono text-[10px] text-(--color-text) focus:border-(--color-accent) focus:outline-none"
           spellCheck={false}
         />
         <ComboboxButton
           aria-label="Toggle timezone list"
           className="absolute inset-y-0 right-0 flex items-center px-1.5 text-(--color-text-faint) hover:text-(--color-text)"
         >
-          <span aria-hidden style={{ fontFamily: "var(--font-pixel)", fontSize: 10 }}>
+          <span aria-hidden className="font-pixel text-[10px]">
             ▾
           </span>
         </ComboboxButton>
@@ -251,7 +237,7 @@ function TimezoneSelect({
             <ComboboxOption
               key={tz}
               value={tz}
-              className="cursor-pointer px-2 py-1 font-mono text-[10px] tracking-[0.05em] text-(--color-text-muted) data-[focus]:bg-(--color-accent)/15 data-[focus]:text-(--color-accent) data-[selected]:text-(--color-accent)"
+              className="cursor-pointer px-2 py-1 font-mono text-[10px] text-(--color-text-muted) data-[focus]:bg-(--color-accent)/15 data-[focus]:text-(--color-accent) data-[selected]:text-(--color-accent)"
             >
               {tz}
             </ComboboxOption>

--- a/dash/src/app/scenes/gif.tsx
+++ b/dash/src/app/scenes/gif.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { parseGIF, decompressFrames, type ParsedFrame } from "gifuct-js";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import {
   defaultGifConfig,
@@ -11,8 +11,12 @@ import {
 
 import { ComposerShell } from "@/app/components/ComposerShell";
 import { Fader } from "@/app/components/Fader";
+import { UploadRow } from "@/app/components/UploadRow";
+import { Alert, PixelValue } from "@/app/components/ui";
 import { panels } from "@/utils/actions";
+import { pad } from "@/utils/format";
 import { useDebouncedSetMode } from "@/utils/useDebouncedSetMode";
+import { useSyncedFromProp } from "@/utils/useSyncedFromProp";
 
 const PANEL_W = 64;
 const PANEL_H = 64;
@@ -160,8 +164,9 @@ async function decodeGif(file: File): Promise<GifSceneConfig> {
     // Bulk-copy the RGBA Uint8ClampedArray; Array.from is far faster
     // than a per-byte assignment loop over ~16K elements per frame.
     const bitmap = Array.from(data);
-    // Per-frame delay: gifuct returns delay in 1/100s units.
-    const delay_ms = Math.max(MIN_DELAY_MS, (frame.delay ?? 10) * 10);
+    // Per-frame delay: gifuct already converts the GIF's 1/100s units
+    // to milliseconds (and substitutes 100ms for a missing delay).
+    const delay_ms = Math.max(MIN_DELAY_MS, frame.delay ?? 100);
     frames.push({ bitmap, delay_ms });
   }
 
@@ -186,36 +191,54 @@ export function GifComposer({
   panelId: string;
   config: GifSceneConfig;
 }) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [busy, setBusy] = useState(false);
+  // "decode" is CPU-bound canvas work; "transmit" is the multi-second
+  // ~720KB Supabase write. Splitting the label keeps the long second
+  // phase from reading as a hung decode.
+  const [phase, setPhase] = useState<"decode" | "transmit" | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  // Local draft of the speed so the fader/readouts respond instantly:
+  // binding straight to `config.speed` lets the 1Hz page re-render
+  // yank the thumb back mid-drag until the realtime echo lands.
+  const [draftSpeed, setDraftSpeed] = useSyncedFromProp(
+    `${panelId}:gif`,
+    config.speed,
+  );
 
   // Speed slider goes through the debounced path so a drag doesn't
   // ship the entire (~720KB) frame payload to Supabase per
-  // intermediate value. File upload + flush stays a direct call —
-  // upload is a single user gesture that shouldn't queue.
-  const [pushSpeedDebounced, flushSpeed] =
-    useDebouncedSetMode<GifSceneConfig>(panelId, "gif");
+  // intermediate value. File upload stays a direct call — upload is
+  // a single user gesture that shouldn't queue.
+  const speedWriter = useDebouncedSetMode<GifSceneConfig>(panelId, "gif");
 
   const handleFile = async (file: File) => {
-    setBusy(true);
+    setPhase("decode");
     setErr(null);
     try {
-      // Cancel any pending speed write — the new file's
-      // decoded config supersedes it.
-      flushSpeed();
+      // Drop any staged speed write (the new file's decoded config
+      // supersedes it), then wait out any write already in flight —
+      // a slow speed write landing AFTER the upload's setMode would
+      // clobber the new gif with the old gif's frames.
+      speedWriter.cancel();
+      await speedWriter.settle();
       const next = await decodeGif(file);
+      setPhase("transmit");
       await panels.setMode.call(panelId, "gif", next);
+      // The decoded config resets speed to 1, but the draft's key
+      // (panelId:gif) doesn't change on upload — reset it manually so
+      // the fader doesn't keep showing the old gif's speed.
+      setDraftSpeed(1);
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
-      setBusy(false);
+      setPhase(null);
     }
   };
 
   const setSpeed = (next: number) => {
     if (config.frames.length === 0) return;
-    pushSpeedDebounced({ ...config, speed: next });
+    setDraftSpeed(next);
+    speedWriter.push({ ...config, speed: next });
   };
 
   const hasFrames = config.frames.length > 0;
@@ -224,9 +247,10 @@ export function GifComposer({
     config.source_frame_count > config.frames.length;
 
   // Total looped duration for the diagnostic readout — accounts for
-  // the playback speed the user has dialed in.
+  // the playback speed the user has dialed in (draft, so the stat
+  // tracks the fader instead of lagging until the server echo).
   const totalMs = config.frames.reduce((acc, f) => acc + f.delay_ms, 0);
-  const effectiveLoopMs = totalMs / Math.max(0.05, config.speed);
+  const effectiveLoopMs = totalMs / Math.max(0.05, draftSpeed);
 
   return (
     <ComposerShell
@@ -234,93 +258,64 @@ export function GifComposer({
       status={`max ${MAX_FRAMES} frames · 64×64`}
       ariaLabel="GIF configuration"
     >
-      <div className="space-y-5 px-4 pb-5 pt-5">
-        <div>
-          <div className="mb-7 font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-            :: upload
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={busy}
-              className="border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-2 font-mono text-xs uppercase tracking-[0.3em] text-(--color-accent) transition hover:bg-(--color-accent)/20 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {busy ? "decoding…" : "choose .gif"}
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/gif"
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) void handleFile(file);
-                e.target.value = "";
-              }}
+      <UploadRow
+        accept="image/gif"
+        idleLabel="choose .gif"
+        busyLabel={phase === "transmit" ? "transmitting…" : "decoding…"}
+        busy={phase != null}
+        status={
+          hasFrames
+            ? `${config.source ?? "uploaded"} · ${config.width}×${config.height}`
+            : "no gif loaded"
+        }
+        onFile={(file) => void handleFile(file)}
+      />
+
+      {err ? <Alert>err: {err}</Alert> : null}
+
+      {hasFrames ? (
+        <>
+          <div className="border-t border-dashed border-(--color-hairline)" />
+
+          <Fader
+            label="speed"
+            value={draftSpeed}
+            min={SPEED_PRESETS[0]}
+            max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
+            step={0.05}
+            onChange={setSpeed}
+            format={(v) => `${v.toFixed(2)}x`}
+            endpoints={["slow", "fast"]}
+            presets={SPEED_PRESETS}
+            presetLabel={(v) => `${v}x`}
+            ariaLabel="GIF speed"
+          />
+
+          <div className="border-t border-dashed border-(--color-hairline)" />
+
+          <div className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-4">
+            <Stat label="frames" value={pad(config.frames.length, 2)} />
+            <Stat
+              label="loop"
+              value={`${(effectiveLoopMs / 1000).toFixed(2)}s`}
             />
-            {hasFrames ? (
-              <span className="truncate font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-                {config.source ?? "uploaded"} · {config.width}×{config.height}
-              </span>
-            ) : (
-              <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-                no gif loaded
-              </span>
-            )}
-          </div>
-        </div>
-
-        {err ? (
-          <div className="border border-(--color-danger)/40 bg-(--color-danger)/5 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-danger)">
-            err: {err}
-          </div>
-        ) : null}
-
-        {hasFrames ? (
-          <>
-            <div className="border-t border-dashed border-(--color-hairline)" />
-
-            <Fader
-              label="// speed"
-              value={config.speed}
-              min={SPEED_PRESETS[0]}
-              max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
-              step={0.05}
-              onChange={setSpeed}
-              format={(v) => `${v.toFixed(2)}x`}
-              endpoints={["slow", "fast"]}
-              presets={SPEED_PRESETS}
-              presetLabel={(v) => `${v}x`}
-              ariaLabel="GIF speed"
+            <Stat
+              label="speed"
+              value={`${draftSpeed.toFixed(2)}x`}
+              tone={draftSpeed === 1 ? undefined : "warn"}
             />
-
-            <div className="border-t border-dashed border-(--color-hairline)" />
-
-            <div className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-4">
-              <Stat label="frames" value={pad(config.frames.length, 2)} />
-              <Stat
-                label="loop"
-                value={`${(effectiveLoopMs / 1000).toFixed(2)}s`}
-              />
-              <Stat
-                label="speed"
-                value={`${config.speed.toFixed(2)}x`}
-                tone={config.speed === 1 ? undefined : "warn"}
-              />
-              <Stat
-                label="source"
-                value={
-                  trimmed
-                    ? `${config.frames.length}/${config.source_frame_count}`
-                    : "full"
-                }
-                tone={trimmed ? "warn" : "ok"}
-              />
-            </div>
-          </>
-        ) : null}
-      </div>
+            <Stat
+              label="source"
+              value={
+                trimmed
+                  ? `${config.frames.length}/${config.source_frame_count}`
+                  : "full"
+              }
+              tone={trimmed ? "warn" : "ok"}
+            />
+          </div>
+        </>
+      ) : null}
     </ComposerShell>
   );
 }
@@ -345,16 +340,9 @@ function Stat({
       <span className="font-mono text-[9px] uppercase tracking-[0.3em] text-(--color-text-dim)">
         {label}
       </span>
-      <span
-        className={`tabular-nums ${valueClass}`}
-        style={{ fontFamily: "var(--font-pixel)", fontSize: 14 }}
-      >
+      <PixelValue size="md" className={valueClass}>
         {value}
-      </span>
+      </PixelValue>
     </div>
   );
-}
-
-function pad(n: number, width: number): string {
-  return String(n).padStart(width, "0");
 }

--- a/dash/src/app/scenes/image.tsx
+++ b/dash/src/app/scenes/image.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import {
   defaultImageConfig,
@@ -8,6 +8,8 @@ import {
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { UploadRow } from "@/app/components/UploadRow";
+import { Alert } from "@/app/components/ui";
 import { panels } from "@/utils/actions";
 
 const PANEL_W = 64;
@@ -87,7 +89,6 @@ export function ImageComposer({
   panelId: string;
   config: ImageSceneConfig;
 }) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -108,49 +109,20 @@ export function ImageComposer({
 
   return (
     <ComposerShell title="image" status="static · 64×64 max" ariaLabel="Image configuration">
-      <div className="space-y-4 px-4 pb-5 pt-5">
-        <div>
-          <div className="mb-7 font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-            :: upload
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={busy}
-              className="border border-(--color-accent)/60 bg-(--color-accent)/10 px-4 py-2 font-mono text-xs uppercase tracking-[0.3em] text-(--color-accent) transition hover:bg-(--color-accent)/20 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {busy ? "loading…" : "choose file"}
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) void handleFile(file);
-                e.target.value = "";
-              }}
-            />
-            {hasImage ? (
-              <span className="truncate font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-                {config.source ?? "uploaded"} · {config.width}×{config.height}
-              </span>
-            ) : (
-              <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-                no image set
-              </span>
-            )}
-          </div>
-        </div>
+      <UploadRow
+        accept="image/*"
+        idleLabel="choose file"
+        busyLabel="loading…"
+        busy={busy}
+        status={
+          hasImage
+            ? `${config.source ?? "uploaded"} · ${config.width}×${config.height}`
+            : "no image set"
+        }
+        onFile={(file) => void handleFile(file)}
+      />
 
-        {err ? (
-          <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-(--color-danger)">
-            err: {err}
-          </p>
-        ) : null}
-      </div>
+      {err ? <Alert>err: {err}</Alert> : null}
     </ComposerShell>
   );
 }

--- a/dash/src/app/scenes/index.ts
+++ b/dash/src/app/scenes/index.ts
@@ -110,8 +110,9 @@ export const SCENES: Record<PanelMode, SceneRegistration> = {
         Text: {
           // EntriesList drives the stored entries; MatrixPreview folds
           // them in. The page only contributes the live preview.
+          // `scroll` is deliberately omitted so MatrixPreview can fill
+          // in the live panel scroll before handing the frame to WASM.
           entries: previewEntry ? [previewEntry] : [],
-          scroll: 0,
         },
       };
     },

--- a/dash/src/app/scenes/life.tsx
+++ b/dash/src/app/scenes/life.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   DEFAULT_LIFE_CONFIG,
@@ -10,6 +10,7 @@ import {
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { ControlRow } from "@/app/components/ControlRow";
 import { SegmentedToggle } from "@/app/components/SegmentedToggle";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
 import { parseRgb } from "@/utils/color";
@@ -75,45 +76,68 @@ export function useLifeScene(
   useEffect(() => {
     if (!enabled) return;
     let raf = 0;
-    const tick = () => {
-      framesRef.current += 1;
-      if (framesRef.current >= intervalRef.current) {
-        framesRef.current = 0;
-        setCells((prev) => {
-          const next = step(prev);
-          generationsRef.current += 1;
-          const pop = population(next);
-          recentPopRef.current = [...recentPopRef.current.slice(1), pop];
-          const stalled =
-            recentPopRef.current[0] !== 0 &&
-            recentPopRef.current.every((p) => p === pop);
-          if (
-            stalled ||
-            generationsRef.current >= RESEED_GENERATIONS ||
-            pop < 5
-          ) {
-            generationsRef.current = 0;
-            recentPopRef.current = [0, 0, 0, 0];
-            return seed();
-          }
-          return next;
-        });
-      }
+    let lastTs: number | null = null;
+    const stepOnce = () => {
+      setCells((prev) => {
+        const next = step(prev);
+        generationsRef.current += 1;
+        const pop = population(next);
+        recentPopRef.current = [...recentPopRef.current.slice(1), pop];
+        const stalled =
+          recentPopRef.current[0] !== 0 &&
+          recentPopRef.current.every((p) => p === pop);
+        if (
+          stalled ||
+          generationsRef.current >= RESEED_GENERATIONS ||
+          pop < 5
+        ) {
+          generationsRef.current = 0;
+          recentPopRef.current = [0, 0, 0, 0];
+          return seed();
+        }
+        return next;
+      });
     };
-    const loop = () => {
-      if (!document.hidden) tick();
+    // `step_interval_frames` is defined against the driver's ~60fps
+    // render loop, but rAF fires at the display's refresh rate — one
+    // logical frame per callback would run 2-2.4x too fast on a
+    // 120/144Hz screen. Accumulate wall-clock time as 60fps-equivalent
+    // frames instead. dt is clamped so a janky frame can't burst-step,
+    // and lastTs advances even while hidden so a hidden period doesn't
+    // accumulate into a catch-up sprint on return.
+    const loop = (ts: number) => {
+      if (lastTs !== null) {
+        const dt = Math.min(ts - lastTs, 100);
+        if (!document.hidden) {
+          framesRef.current += dt / (1000 / 60);
+          // Subtract instead of resetting to zero so the fractional
+          // remainder carries over — resetting would drift slow.
+          while (framesRef.current >= intervalRef.current) {
+            framesRef.current -= intervalRef.current;
+            stepOnce();
+          }
+        }
+      }
+      lastTs = ts;
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
   }, [enabled]);
 
-  return {
-    color: config.color,
-    lattice_width: W,
-    lattice_height: H,
-    cells: Array.from(cells),
-  };
+  // The simulator dedupes scene pushes by cells-array reference; an
+  // unmemoized return would rebuild the array every render and either
+  // re-push constantly or — before this pair of fixes — freeze the
+  // preview.
+  return useMemo(
+    () => ({
+      color: config.color,
+      lattice_width: W,
+      lattice_height: H,
+      cells: Array.from(cells),
+    }),
+    [cells, config.color],
+  );
 }
 
 function seed(): Uint8Array {
@@ -179,31 +203,26 @@ export function LifeComposer({
 
   return (
     <ComposerShell title="life" status="conway · ambient" ariaLabel="Life configuration">
-      <div className="space-y-5 px-4 py-4">
-        <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-          live cells reseed automatically when the simulation stalls
-          or goes extinct.
-        </p>
-        <div className="flex items-center justify-between gap-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-            :: speed
-          </span>
-          <SegmentedToggle
-            ariaLabel="Simulation speed"
-            options={SPEED_PRESETS.map((p) => ({ id: p.id, label: p.label }))}
-            value={activePreset}
-            onChange={(id) => {
-              const preset = SPEED_PRESETS.find((p) => p.id === id);
-              if (preset)
-                update({ ...draft, step_interval_frames: preset.frames });
-            }}
-          />
-        </div>
-        <SolidColorPicker
-          value={draft.color}
-          onChange={(color) => update({ ...draft, color })}
+      <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
+        live cells reseed automatically when the simulation stalls
+        or goes extinct.
+      </p>
+      <ControlRow label="speed">
+        <SegmentedToggle
+          ariaLabel="Simulation speed"
+          options={SPEED_PRESETS.map((p) => ({ id: p.id, label: p.label }))}
+          value={activePreset}
+          onChange={(id) => {
+            const preset = SPEED_PRESETS.find((p) => p.id === id);
+            if (preset)
+              update({ ...draft, step_interval_frames: preset.frames });
+          }}
         />
-      </div>
+      </ControlRow>
+      <SolidColorPicker
+        value={draft.color}
+        onChange={(color) => update({ ...draft, color })}
+      />
     </ComposerShell>
   );
 }

--- a/dash/src/app/scenes/paint.tsx
+++ b/dash/src/app/scenes/paint.tsx
@@ -5,8 +5,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { parseImageConfig } from "./image";
 import { type ImageSceneConfig } from "./types";
 
+import { CheckRow } from "@/app/components/CheckRow";
 import { ComposerShell } from "@/app/components/ComposerShell";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
+import { FOCUS_RING } from "@/app/components/ui";
+import { useRovingRadio } from "@/app/components/useRovingRadio";
 import { panels } from "@/utils/actions";
 import { LED_ORANGE, parseRgb, type Rgb } from "@/utils/color";
 
@@ -64,8 +67,11 @@ export function PaintComposer({
   // unless we're mid-stroke or the new payload is exactly what we
   // just sent (compared byte-for-byte).
   useEffect(() => {
-    const next = bitmapFrom(config);
-    if (!next) return;
+    // A blank/non-64×64 config means "nothing painted" — render it as
+    // an empty canvas rather than leaving stale artwork up (e.g. the
+    // server was cleared from another tab).
+    const next =
+      bitmapFrom(config) ?? new Uint8ClampedArray(PANEL_W * PANEL_H * 4);
     if (strokeInFlightRef.current) return;
     if (lastPushedRef.current && bytesEqual(next, lastPushedRef.current)) return;
     setBitmap(next);
@@ -177,6 +183,25 @@ export function PaintComposer({
     commit(next);
   };
 
+  // Clear wipes the live panel in one tap and sits right next to redo
+  // — too easy to fat-finger. First tap arms ("sure?"), second commits;
+  // auto-disarm so a forgotten confirm isn't a landmine. Undo still
+  // works after a clear (clear runs through beginStroke as usual).
+  const [clearArmed, setClearArmed] = useState(false);
+  useEffect(() => {
+    if (!clearArmed) return;
+    const timer = setTimeout(() => setClearArmed(false), 3000);
+    return () => clearTimeout(timer);
+  }, [clearArmed]);
+  const handleClearTap = () => {
+    if (!clearArmed) {
+      setClearArmed(true);
+      return;
+    }
+    setClearArmed(false);
+    clear();
+  };
+
   // Single-cell stroke (keyboard paint) — runs the full begin→step→
   // commit cycle so it shares undo/persist with pointer strokes.
   const paintCell = (x: number, y: number) => {
@@ -195,74 +220,78 @@ export function PaintComposer({
 
   return (
     <ComposerShell title="paint" status="64×64 pixel editor" ariaLabel="Paint configuration">
-      <div className="space-y-4 px-4 py-4">
-        {/* Tool row */}
-        <div className="flex flex-wrap items-center gap-2">
-          <ToolGroup
-            tool={tool}
-            onChange={(t) => {
-              setTool(t);
-              if (t === "brush") rememberColor(color);
-            }}
-          />
-          <span aria-hidden className="flex-1" />
-          <SmallButton onClick={undo} disabled={undoLen === 0}>
-            undo
-          </SmallButton>
-          <SmallButton onClick={redo} disabled={redoLen === 0}>
-            redo
-          </SmallButton>
-          <SmallButton onClick={clear} variant="danger">
-            clear
-          </SmallButton>
-        </div>
-
-        {/* Canvas */}
-        <PaintCanvas
-          bitmap={bitmap}
-          grid={grid}
-          onStrokeBegin={beginStroke}
-          onStrokeStep={(working, x, y) => {
-            handlePixel(working, x, y);
-            // Persisting only on stroke-end — Supabase write rate
-            // limit + driver ConfigCache invalidation make per-pixel
-            // writes a thrash trap. Mid-stroke we just bump local
-            // state for the paint-trail feedback.
-            setBitmap(new Uint8ClampedArray(working));
+      {/* Tool row */}
+      <div className="flex flex-wrap items-center gap-2">
+        <ToolGroup
+          tool={tool}
+          onChange={(t) => {
+            setTool(t);
+            if (t === "brush") rememberColor(color);
           }}
-          onStrokeEnd={(working) => commit(working)}
-          onPaintCell={paintCell}
         />
-
-        {/* Grid + recent colours */}
-        <div className="flex items-center justify-between gap-3">
-          <label className="flex cursor-pointer items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-muted)">
-            <input
-              type="checkbox"
-              checked={grid}
-              onChange={(e) => setGrid(e.target.checked)}
-              className="h-3 w-3 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)"
-            />
-            grid
-          </label>
-          <div className="flex flex-wrap items-center gap-1">
-            {recentColors.map((c, i) => (
-              <button
-                key={`${c.r}-${c.g}-${c.b}-${i}`}
-                type="button"
-                onClick={() => changeColor(c)}
-                className="h-4 w-4 border border-(--color-border) hover:border-(--color-text) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
-                style={{ background: `rgb(${c.r},${c.g},${c.b})` }}
-                aria-label={`Pick rgb(${c.r},${c.g},${c.b})`}
-              />
-            ))}
-          </div>
-        </div>
-
-        <div className="border-t border-dashed border-(--color-hairline)" />
-
-        <SolidColorPicker value={color} onChange={changeColor} />
+        <span aria-hidden className="flex-1" />
+        <SmallButton onClick={undo} disabled={undoLen === 0}>
+          undo
+        </SmallButton>
+        <SmallButton onClick={redo} disabled={redoLen === 0}>
+          redo
+        </SmallButton>
+        <SmallButton
+          onClick={handleClearTap}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setClearArmed(false);
+          }}
+          variant="danger"
+          armed={clearArmed}
+        >
+          {clearArmed ? "sure?" : "clear"}
+        </SmallButton>
       </div>
+
+      {/* Canvas */}
+      <PaintCanvas
+        bitmap={bitmap}
+        grid={grid}
+        onStrokeBegin={beginStroke}
+        onStrokeStep={(working, x, y) => {
+          handlePixel(working, x, y);
+          // Persisting only on stroke-end — Supabase write rate
+          // limit + driver ConfigCache invalidation make per-pixel
+          // writes a thrash trap. Mid-stroke we just bump local
+          // state for the paint-trail feedback.
+          setBitmap(new Uint8ClampedArray(working));
+        }}
+        onStrokeEnd={(working) => commit(working)}
+        onPaintCell={paintCell}
+      />
+
+      {/* Grid + recent colours */}
+      <div className="flex items-center justify-between gap-3">
+        <CheckRow sigil={false} label="grid" checked={grid} onChange={setGrid} />
+        <div className="flex flex-wrap items-center gap-1.5">
+          {recentColors.map((c, i) => (
+            // 24×24 hit area around a 16px painted square — the bare
+            // 16px buttons guaranteed mis-taps on touch.
+            <button
+              key={`${c.r}-${c.g}-${c.b}-${i}`}
+              type="button"
+              onClick={() => changeColor(c)}
+              className={`group flex h-6 w-6 items-center justify-center ${FOCUS_RING}`}
+              aria-label={`Pick rgb(${c.r},${c.g},${c.b})`}
+            >
+              <span
+                aria-hidden
+                className="block h-4 w-4 border border-(--color-border) transition group-hover:border-(--color-text)"
+                style={{ background: `rgb(${c.r},${c.g},${c.b})` }}
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-t border-dashed border-(--color-hairline)" />
+
+      <SolidColorPicker value={color} onChange={changeColor} />
     </ComposerShell>
   );
 }
@@ -277,6 +306,17 @@ function bytesEqual(a: Uint8ClampedArray, b: Uint8ClampedArray): boolean {
 }
 
 /* ─── canvas ──────────────────────────────────────────────────────── */
+
+// Canvas 2D can't consume CSS custom properties directly, so resolve
+// the surface token once and cache the string — the palette is static,
+// and a getComputedStyle on every repaint would be wasted layout work.
+let cachedSurfaceColor: string | null = null;
+function canvasSurfaceColor(canvas: HTMLCanvasElement): string {
+  cachedSurfaceColor ??=
+    getComputedStyle(canvas).getPropertyValue("--color-surface").trim() ||
+    "#0f0f12";
+  return cachedSurfaceColor;
+}
 
 function PaintCanvas({
   bitmap,
@@ -302,6 +342,11 @@ function PaintCanvas({
   // Keyboard cursor position. Arrows move it; Enter/Space paint the
   // cell under it. Rendered as a highlighted outline so it's visible.
   const [cursor, setCursor] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  // Non-visual echo of the keyboard model: the cursor overlay is the
+  // only feedback otherwise, so a screen reader hears nothing. null
+  // until the first keyboard interaction keeps the live region quiet
+  // on mount.
+  const [lastAction, setLastAction] = useState<"move" | "paint" | null>(null);
 
   // Repaint canvas whenever the bitmap (or cursor/grid) changes. Cell
   // size derived from the canvas's actual rendered width to stay crisp.
@@ -317,7 +362,7 @@ function PaintCanvas({
       ctx.imageSmoothingEnabled = false;
 
       // Background — checkered, dim.
-      ctx.fillStyle = "#0d0d11";
+      ctx.fillStyle = canvasSurfaceColor(canvas);
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
       // Pixels.
@@ -383,6 +428,10 @@ function PaintCanvas({
   };
 
   const handleDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    // Primary button only — a right-click stroke whose pointerup gets
+    // eaten by the context menu would leave strokeInFlightRef stuck
+    // and block server sync forever.
+    if (!e.isPrimary || e.button !== 0) return;
     e.currentTarget.setPointerCapture(e.pointerId);
     const working = onStrokeBegin();
     workingRef.current = working;
@@ -409,11 +458,32 @@ function PaintCanvas({
     lastCellRef.current = { x, y };
   };
 
-  const handleUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
-    if (workingRef.current) onStrokeEnd(workingRef.current);
+  // Shared stroke finalizer: refs are nulled before onStrokeEnd so a
+  // re-entrant capture-loss event can't double-commit.
+  const finishStroke = () => {
+    const working = workingRef.current;
     workingRef.current = null;
     lastCellRef.current = null;
+    if (working) onStrokeEnd(working);
+  };
+
+  const handleUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    // Capture may already be gone (pointercancel, or a down we never
+    // captured) — releasing then throws.
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    finishStroke();
+  };
+
+  // Safety net for every capture-loss path that skips pointerup —
+  // context menu, tab switch, pointercancel. Capture is already gone
+  // here, so we must NOT touch releasePointerCapture; just finalize.
+  // Idempotent after a normal up (workingRef is already null). This
+  // guarantees strokeInFlightRef clears no matter how the stroke dies,
+  // so server sync can never be blocked permanently.
+  const handleLostCapture = () => {
+    finishStroke();
   };
 
   // Keyboard model: arrows move the cursor (clamped to the grid),
@@ -423,26 +493,37 @@ function PaintCanvas({
       case "ArrowLeft":
         e.preventDefault();
         setCursor((c) => ({ ...c, x: Math.max(0, c.x - 1) }));
+        setLastAction("move");
         break;
       case "ArrowRight":
         e.preventDefault();
         setCursor((c) => ({ ...c, x: Math.min(PANEL_W - 1, c.x + 1) }));
+        setLastAction("move");
         break;
       case "ArrowUp":
         e.preventDefault();
         setCursor((c) => ({ ...c, y: Math.max(0, c.y - 1) }));
+        setLastAction("move");
         break;
       case "ArrowDown":
         e.preventDefault();
         setCursor((c) => ({ ...c, y: Math.min(PANEL_H - 1, c.y + 1) }));
+        setLastAction("move");
         break;
       case "Enter":
       case " ":
         e.preventDefault();
         onPaintCell(cursor.x, cursor.y);
+        setLastAction("paint");
         break;
     }
   };
+
+  // 1-based for human ears; the grid itself is 0-indexed internally.
+  const announcement =
+    lastAction === null
+      ? ""
+      : `${lastAction === "paint" ? "painted " : ""}row ${cursor.y + 1}, column ${cursor.x + 1}`;
 
   // Cursor outline as a CSS overlay so it doesn't fight the canvas's
   // own repaint cycle. Position is a percentage of the grid.
@@ -459,7 +540,7 @@ function PaintCanvas({
       aria-label="Paint canvas — arrow keys move the cursor, Enter or Space paints"
       tabIndex={0}
       onKeyDown={handleKeyDown}
-      className="relative mx-auto aspect-square w-full max-w-[384px] border border-(--color-border) bg-(--color-bg) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)"
+      className={`relative mx-auto aspect-square w-full max-w-[384px] border border-(--color-border) bg-(--color-bg) ${FOCUS_RING}`}
     >
       <canvas
         ref={canvasRef}
@@ -467,6 +548,7 @@ function PaintCanvas({
         onPointerMove={handleMove}
         onPointerUp={handleUp}
         onPointerCancel={handleUp}
+        onLostPointerCapture={handleLostCapture}
         className="block h-full w-full touch-none cursor-crosshair"
         aria-hidden
       />
@@ -475,11 +557,18 @@ function PaintCanvas({
         className="pointer-events-none absolute border border-(--color-accent) shadow-[0_0_4px_var(--color-accent)]"
         style={cursorStyle}
       />
+      {/* Spoken echo of the keyboard model — cursor moves and paints
+       * otherwise produce zero non-visual output. */}
+      <span role="status" className="sr-only">
+        {announcement}
+      </span>
     </div>
   );
 }
 
 /* ─── tool group ──────────────────────────────────────────────────── */
+
+const TOOL_IDS = ["brush", "fill", "eraser", "eyedrop"] as const;
 
 function ToolGroup({
   tool,
@@ -494,22 +583,27 @@ function ToolGroup({
     { id: "eraser", glyph: "▢", label: "erase" },
     { id: "eyedrop", glyph: "◉", label: "pick" },
   ];
+  // Roving tabindex so the radiogroup honors the radio contract:
+  // arrows move + select, one Tab stop for the whole group.
+  const radio = useRovingRadio(TOOL_IDS, tool, onChange);
   return (
-    <div role="radiogroup" aria-label="Tool" className="flex items-center gap-px border border-(--color-border)">
-      {tools.map((t) => {
+    <div
+      role="radiogroup"
+      aria-label="Tool"
+      onKeyDown={radio.onKeyDown}
+      className="flex items-center gap-px border border-(--color-border)"
+    >
+      {tools.map((t, i) => {
         const active = t.id === tool;
         return (
           <button
             key={t.id}
-            type="button"
-            role="radio"
-            onClick={() => onChange(t.id)}
+            {...radio.itemProps(t.id, i)}
             title={t.label}
             aria-label={t.label}
-            aria-checked={active}
             className={[
               "flex h-7 items-center gap-1.5 px-2 font-mono text-[10px] uppercase tracking-[0.25em] transition-colors",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
+              `${FOCUS_RING} focus-visible:ring-inset`,
               active
                 ? "bg-(--color-accent)/15 text-(--color-accent)"
                 : "text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
@@ -528,25 +622,33 @@ function ToolGroup({
 
 function SmallButton({
   onClick,
+  onKeyDown,
   disabled,
   variant,
+  armed,
   children,
 }: {
   onClick: () => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   variant?: "danger";
+  /** Armed confirm state — full danger fill (clear's "sure?" step). */
+  armed?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      onKeyDown={onKeyDown}
       disabled={disabled}
       className={[
         "border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.25em] transition-colors disabled:cursor-not-allowed disabled:opacity-40",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
+        FOCUS_RING,
         variant === "danger"
-          ? "border-(--color-danger)/40 text-(--color-danger)/80 hover:bg-(--color-danger)/10 hover:text-(--color-danger)"
+          ? armed
+            ? "border-(--color-danger)/50 bg-(--color-danger)/10 text-(--color-danger) hover:bg-(--color-danger)/20"
+            : "border-(--color-danger)/40 text-(--color-danger)/80 hover:bg-(--color-danger)/10 hover:text-(--color-danger)"
           : "border-(--color-border) text-(--color-text-muted) hover:border-(--color-border-strong) hover:text-(--color-text)",
       ].join(" ")}
     >

--- a/dash/src/app/scenes/shapes.tsx
+++ b/dash/src/app/scenes/shapes.tsx
@@ -9,8 +9,11 @@ import {
   type ShapesSceneConfig,
 } from "./types";
 
+import { CheckRow } from "@/app/components/CheckRow";
 import { ComposerShell } from "@/app/components/ComposerShell";
 import { Fader } from "@/app/components/Fader";
+import { FOCUS_RING, MicroLabel } from "@/app/components/ui";
+import { useRovingRadio } from "@/app/components/useRovingRadio";
 import { SolidColorPicker } from "@/app/components/SolidColorPicker";
 import { parseRgb } from "@/utils/color";
 import { useComposerConfig } from "@/utils/useComposerConfig";
@@ -23,6 +26,8 @@ const SHAPES: { id: ShapeKind; label: string; glyph: string; blurb: string }[] =
   { id: "Torus", label: "torus", glyph: "◯", blurb: "donut" },
   { id: "Hypercube", label: "tesseract", glyph: "◫", blurb: "4d cube" },
 ];
+
+const SHAPE_IDS = SHAPES.map((s) => s.id);
 
 const SPEED_PRESETS = [0.25, 0.5, 1, 2, 4, 8];
 
@@ -60,6 +65,9 @@ export function ShapesComposer({
     "shapes",
     config,
   );
+  const shapeRadio = useRovingRadio(SHAPE_IDS, draft.kind, (kind) =>
+    update({ ...draft, kind }),
+  );
 
   return (
     <ComposerShell
@@ -67,130 +75,112 @@ export function ShapesComposer({
       status="rotating wireframe"
       ariaLabel="Shapes configuration"
     >
-      <div className="space-y-6 px-4 pb-5 pt-5">
-        {/* Shape picker */}
-        <div>
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-            :: shape
-          </div>
-          <div
-            role="radiogroup"
-            aria-label="Shape"
-            className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-3"
-          >
-            {SHAPES.map((s) => {
-              const active = s.id === draft.kind;
-              return (
-                <button
-                  key={s.id}
-                  type="button"
-                  role="radio"
-                  aria-checked={active}
-                  onClick={() => update({ ...draft, kind: s.id })}
-                  title={s.blurb}
+      {/* Shape picker */}
+      <div>
+        <MicroLabel as="div" className="mb-3">
+          shape
+        </MicroLabel>
+        <div
+          role="radiogroup"
+          aria-label="Shape"
+          onKeyDown={shapeRadio.onKeyDown}
+          className="grid grid-cols-2 gap-px border border-(--color-border) bg-(--color-border) sm:grid-cols-3"
+        >
+          {SHAPES.map((s, i) => {
+            const active = s.id === draft.kind;
+            return (
+              <button
+                key={s.id}
+                {...shapeRadio.itemProps(s.id, i)}
+                title={s.blurb}
+                className={[
+                  "flex items-center gap-3 px-3 py-2.5 text-left transition-colors",
+                  FOCUS_RING,
+                  "focus-visible:ring-inset",
+                  active
+                    ? "bg-(--color-bg) text-(--color-accent)"
+                    : "bg-(--color-surface)/70 text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
+                ].join(" ")}
+              >
+                <span
+                  aria-hidden
                   className={[
-                    "flex items-center gap-3 px-3 py-2.5 text-left transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-inset",
+                    "flex h-7 w-7 shrink-0 items-center justify-center border font-pixel text-[18px] leading-none",
                     active
-                      ? "bg-(--color-bg) text-(--color-accent)"
-                      : "bg-(--color-surface)/70 text-(--color-text-muted) hover:bg-(--color-surface-2) hover:text-(--color-text)",
+                      ? "border-(--color-accent)/60 bg-(--color-accent)/10 text-(--color-accent)"
+                      : "border-(--color-border) bg-(--color-bg)/60 text-(--color-text-dim)",
                   ].join(" ")}
                 >
+                  {s.glyph}
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate font-mono text-[11px] uppercase tracking-[0.3em]">
+                    {s.label}
+                  </span>
                   <span
-                    aria-hidden
                     className={[
-                      "flex h-7 w-7 shrink-0 items-center justify-center border",
+                      "truncate font-mono text-[10px] tracking-wide",
                       active
-                        ? "border-(--color-accent)/60 bg-(--color-accent)/10 text-(--color-accent)"
-                        : "border-(--color-border) bg-(--color-bg)/60 text-(--color-text-dim)",
+                        ? "text-(--color-accent)"
+                        : "text-(--color-text-faint)",
                     ].join(" ")}
-                    style={{
-                      fontFamily: "var(--font-pixel)",
-                      fontSize: 18,
-                      lineHeight: 1,
-                    }}
                   >
-                    {s.glyph}
+                    {s.blurb}
                   </span>
-                  <span className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate font-mono text-[11px] uppercase tracking-[0.3em]">
-                      {s.label}
-                    </span>
-                    <span
-                      className={[
-                        "truncate font-mono text-[10px] tracking-wide",
-                        active
-                          ? "text-(--color-accent)"
-                          : "text-(--color-text-faint)",
-                      ].join(" ")}
-                    >
-                      {s.blurb}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
-          </div>
+                </span>
+              </button>
+            );
+          })}
         </div>
-
-        <div className="border-t border-dashed border-(--color-hairline)" />
-
-        {/* Speed */}
-        <Fader
-          label="// speed"
-          value={draft.speed}
-          min={SPEED_PRESETS[0]}
-          max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
-          step={0.05}
-          onChange={(speed) => update({ ...draft, speed })}
-          format={(v) => `${v.toFixed(2)}x`}
-          endpoints={["slow", "fast"]}
-          presets={SPEED_PRESETS}
-          presetLabel={(v) => `${v}x`}
-          ariaLabel="Rotation speed"
-        />
-
-        <div className="border-t border-dashed border-(--color-hairline)" />
-
-        {/* Face opacity — 0 = wireframe-only, 1 = fully filled. Edges
-         * are always drawn on top at full brightness regardless. */}
-        <Fader
-          label="// face opacity"
-          value={draft.opacity}
-          min={0}
-          max={1}
-          step={0.02}
-          onChange={(opacity) => update({ ...draft, opacity })}
-          format={(v) => `${Math.round(v * 100)}%`}
-          endpoints={["wire", "solid"]}
-          ariaLabel="Face opacity"
-        />
-
-        <label className="flex cursor-pointer items-center justify-between gap-3">
-          <span className="flex flex-col gap-0.5">
-            <span className="font-mono text-[10px] uppercase tracking-[0.3em] text-(--color-text-dim)">
-              :: depth shade
-            </span>
-            <span className="font-mono text-[9px] tracking-wide text-(--color-text-faint)">
-              dim back-of-shape edges
-            </span>
-          </span>
-          <input
-            type="checkbox"
-            checked={draft.depth_shade}
-            onChange={(e) => update({ ...draft, depth_shade: e.target.checked })}
-            className="h-3.5 w-3.5 rounded-[1px] border-(--color-border-strong) bg-(--color-bg) text-(--color-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--color-bg)"
-          />
-        </label>
-
-        <div className="border-t border-dashed border-(--color-hairline)" />
-
-        {/* Color */}
-        <SolidColorPicker
-          value={draft.color}
-          onChange={(color) => update({ ...draft, color })}
-        />
       </div>
+
+      <div className="border-t border-dashed border-(--color-hairline)" />
+
+      {/* Speed */}
+      <Fader
+        label="speed"
+        value={draft.speed}
+        min={SPEED_PRESETS[0]}
+        max={SPEED_PRESETS[SPEED_PRESETS.length - 1]}
+        step={0.05}
+        onChange={(speed) => update({ ...draft, speed })}
+        format={(v) => `${v.toFixed(2)}x`}
+        endpoints={["slow", "fast"]}
+        presets={SPEED_PRESETS}
+        presetLabel={(v) => `${v}x`}
+        ariaLabel="Rotation speed"
+      />
+
+      <div className="border-t border-dashed border-(--color-hairline)" />
+
+      {/* Face opacity — 0 = wireframe-only, 1 = fully filled. Edges
+       * are always drawn on top at full brightness regardless. */}
+      <Fader
+        label="face opacity"
+        value={draft.opacity}
+        min={0}
+        max={1}
+        step={0.02}
+        onChange={(opacity) => update({ ...draft, opacity })}
+        format={(v) => `${Math.round(v * 100)}%`}
+        endpoints={["wire", "solid"]}
+        ariaLabel="Face opacity"
+      />
+
+      <CheckRow
+        label="depth shade"
+        hint="dim back-of-shape edges"
+        checked={draft.depth_shade}
+        onChange={(depth_shade) => update({ ...draft, depth_shade })}
+      />
+
+      <div className="border-t border-dashed border-(--color-hairline)" />
+
+      {/* Color */}
+      <SolidColorPicker
+        value={draft.color}
+        onChange={(color) => update({ ...draft, color })}
+      />
     </ComposerShell>
   );
 }

--- a/dash/src/app/scenes/test.tsx
+++ b/dash/src/app/scenes/test.tsx
@@ -10,6 +10,8 @@ import {
 } from "./types";
 
 import { ComposerShell } from "@/app/components/ComposerShell";
+import { FOCUS_RING } from "@/app/components/ui";
+import { useRovingRadio } from "@/app/components/useRovingRadio";
 import { useComposerConfig } from "@/utils/useComposerConfig";
 
 const PATTERNS: { id: TestPatternId; label: string; blurb: string }[] = [
@@ -17,6 +19,8 @@ const PATTERNS: { id: TestPatternId; label: string; blurb: string }[] = [
   { id: "Gradient",     label: "gradient",      blurb: "horizontal R/G/B brightness ramps" },
   { id: "Checkerboard", label: "checkerboard",  blurb: "1×1 checker — surfaces moiré + row-driver shadows" },
 ];
+
+const PATTERN_IDS = PATTERNS.map((p) => p.id);
 
 export function parseTestConfig(raw: unknown): TestSceneConfig {
   if (!raw || typeof raw !== "object") return defaultTestConfig();
@@ -38,47 +42,50 @@ export function TestComposer({
     "test",
     config,
   );
+  const patternRadio = useRovingRadio(PATTERN_IDS, draft.pattern, (pattern) =>
+    update({ pattern }),
+  );
 
   return (
     <ComposerShell title="test" status="diagnostic patterns" ariaLabel="Test pattern configuration">
-      <div className="space-y-3 px-4 py-4">
-        <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
-          static patterns for diagnosing dead pixels, geometry,
-          PWM linearity, moiré.
-        </p>
-        <div role="radiogroup" aria-label="Test pattern" className="space-y-1">
-          {PATTERNS.map((p) => {
-            const active = p.id === draft.pattern;
-            return (
-              <button
-                key={p.id}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                onClick={() => update({ pattern: p.id })}
+      <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-(--color-text-faint)">
+        static patterns for diagnosing dead pixels, geometry,
+        PWM linearity, moiré.
+      </p>
+      <div
+        role="radiogroup"
+        aria-label="Test pattern"
+        onKeyDown={patternRadio.onKeyDown}
+        className="space-y-1"
+      >
+        {PATTERNS.map((p, i) => {
+          const active = p.id === draft.pattern;
+          return (
+            <button
+              key={p.id}
+              {...patternRadio.itemProps(p.id, i)}
+              className={[
+                "flex w-full items-baseline justify-between gap-3 border px-3 py-2 text-left transition",
+                FOCUS_RING,
+                active
+                  ? "border-(--color-accent) bg-(--color-accent)/10"
+                  : "border-(--color-border) hover:border-(--color-border-strong) hover:bg-(--color-surface-2)",
+              ].join(" ")}
+            >
+              <span
                 className={[
-                  "flex w-full items-baseline justify-between gap-3 border px-3 py-2 text-left transition",
-                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)",
-                  active
-                    ? "border-(--color-accent) bg-(--color-accent)/10"
-                    : "border-(--color-border) hover:border-(--color-border-strong) hover:bg-(--color-surface-2)",
+                  "font-mono text-[11px] uppercase tracking-[0.25em]",
+                  active ? "text-(--color-accent)" : "text-(--color-text)",
                 ].join(" ")}
               >
-                <span
-                  className={[
-                    "font-mono text-[11px] uppercase tracking-[0.25em]",
-                    active ? "text-(--color-accent)" : "text-(--color-text)",
-                  ].join(" ")}
-                >
-                  {p.label}
-                </span>
-                <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint)">
-                  {p.blurb}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+                {p.label}
+              </span>
+              <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-(--color-text-faint)">
+                {p.blurb}
+              </span>
+            </button>
+          );
+        })}
       </div>
     </ComposerShell>
   );

--- a/dash/src/app/scenes/types.ts
+++ b/dash/src/app/scenes/types.ts
@@ -57,7 +57,12 @@ export type WireColor =
 
 export type TextScene = {
   entries: TextEntry[];
-  scroll: number;
+  /**
+   * Vertical scroll offset in pixels. The dash-side builder leaves
+   * this undefined so MatrixPreview can fill in the live panel scroll
+   * before serializing for WASM (the Rust side has #[serde(default)]).
+   */
+  scroll?: number;
 };
 
 export type ClockScene = {

--- a/dash/src/globals.css
+++ b/dash/src/globals.css
@@ -88,8 +88,8 @@
   }
 }
 
-/* Bitmap CRT face for the matrix-frame numerals — tiny accent, not
- * worth a next/font import for two uses. */
+/* Bitmap CRT face for the pixel-font readouts (`font-pixel` /
+ * <PixelValue>) — numerals, glyph chips, and the header wordmark. */
 @font-face {
   font-family: "VT323";
   font-style: normal;
@@ -144,12 +144,18 @@ body::before {
 }
 
 /* Range-slider styling: pseudo-elements per browser are the one
- * thing that genuinely doesn't fit Tailwind utilities. */
+ * thing that genuinely doesn't fit Tailwind utilities.
+ *
+ * The input box is 28px tall so the touch target clears the WCAG
+ * floor — the 2px track + 14px thumb stay visually unchanged, the
+ * extra height is invisible hit area (grabbing a 14px thumb on a
+ * phone used to take several attempts). */
 .fader {
   appearance: none;
   -webkit-appearance: none;
   background: transparent;
   cursor: pointer;
+  height: 28px;
 }
 
 .fader::-webkit-slider-runnable-track {

--- a/dash/src/utils/actions.ts
+++ b/dash/src/utils/actions.ts
@@ -3,6 +3,9 @@ import { useEffect, useId, useState } from "react";
 import useSWR, { mutate as globalMutate, useSWRConfig } from "swr";
 
 import { Database } from "@/types/supabase";
+import { rememberModeConfig } from "@/utils/modeConfigCache";
+
+type PanelRow = Database["public"]["Tables"]["panels"]["Row"];
 
 type TextEntryOptions = {
   color:
@@ -138,7 +141,21 @@ export const useRealtimeRevalidation = (): RealtimeStatus => {
           const panelId =
             (payload.new as { panel_id?: string })?.panel_id ??
             (payload.old as { panel_id?: string })?.panel_id;
-          if (panelId) mutate(`/entries/${panelId}`);
+          if (panelId) {
+            mutate(`/entries/${panelId}`);
+          } else {
+            // DELETE events only carry the primary key under the default
+            // replica identity (and RLS strips the rest even with
+            // REPLICA IDENTITY FULL), so we can't tell which panel's
+            // queue changed — invalidate every entries cache rather
+            // than silently going stale until the 60s backstop poll.
+            void mutate(
+              (key) =>
+                typeof key === "string" &&
+                key.startsWith("/entries/") &&
+                !key.startsWith("/entries/scroll/"),
+            );
+          }
         },
       )
       .subscribe((s) => {
@@ -173,6 +190,58 @@ export type PanelMode =
   | "shapes"
   | "test";
 
+/**
+ * Optimistically patch one panel row in the `/panels` SWR cache while
+ * the write round-trips, rolling back if it throws. This gives the
+ * transport buttons / mode tiles / brightness fader the same instant
+ * feel the entries pipeline already has — without it, a tap only takes
+ * effect after the write AND a revalidation (up to 15s when the
+ * realtime channel is down), which reads as a dead button.
+ *
+ * Mutations are serialized through a module-level chain: SWR's
+ * overlapping-mutation semantics make the first mutation skip its
+ * cache commit and let the second commit from a snapshot that
+ * predates the first's patch — i.e. quick pause-then-off taps would
+ * drop the pause from the cache until the realtime echo. One write at
+ * a time sidesteps that class entirely (these are sub-second row
+ * UPDATEs; queueing is imperceptible).
+ */
+let panelWriteChain: Promise<unknown> = Promise.resolve();
+
+const patchPanelOptimistic = (
+  panelId: string,
+  patch: Partial<PanelRow>,
+  write: () => Promise<void>,
+): Promise<void> => {
+  // Leave an unpopulated cache alone — committing a fabricated []
+  // would render "no panels registered" until the next revalidation.
+  const apply = (cur?: PanelRow[]) =>
+    cur ? cur.map((p) => (p.id === panelId ? { ...p, ...patch } : p)) : cur;
+  const run = async () => {
+    await globalMutate(
+      "/panels",
+      async (cur?: PanelRow[]) => {
+        await write();
+        return apply(cur);
+      },
+      {
+        // Patch the DISPLAYED data, not the committed snapshot — the
+        // displayed value carries any still-pending optimistic state.
+        optimisticData: (cur?: PanelRow[], displayed?: PanelRow[]) =>
+          apply(displayed ?? cur) ?? [],
+        rollbackOnError: true,
+        // The realtime echo revalidates with the authoritative row.
+        revalidate: false,
+      },
+    );
+  };
+  const result = panelWriteChain.then(run, run);
+  // The chain itself must never reject, or one failed write would
+  // poison every later mutation.
+  panelWriteChain = result.catch(() => {});
+  return result;
+};
+
 export const panels = {
   get: {
     call: async () => {
@@ -193,54 +262,134 @@ export const panels = {
       mode: PanelMode,
       modeConfig: Record<string, unknown>,
     ) => {
+      const last_updated = new Date().toISOString();
+      // Write-through cache of the last config actually written per
+      // panel:mode, so ModeSwitcher restores the freshest value (the
+      // SWR snapshot lags by debounce + RTT + echo). Stamped with the
+      // same timestamp the row gets, so the cache's newest-wins
+      // arbitration agrees with last_updated.
+      rememberModeConfig(panelId, mode, modeConfig, Date.parse(last_updated));
+      await patchPanelOptimistic(
+        panelId,
+        {
+          mode,
+          mode_config:
+            modeConfig as Database["public"]["Tables"]["panels"]["Row"]["mode_config"],
+          last_updated,
+        },
+        async () => {
+          await supabase
+            .from("panels")
+            .update({
+              mode,
+              mode_config:
+                modeConfig as Database["public"]["Tables"]["panels"]["Update"]["mode_config"],
+              last_updated,
+            })
+            .eq("id", panelId)
+            .throwOnError();
+        },
+      );
+    },
+  },
+
+  /**
+   * Update ONLY mode_config — and only while the panel is still in
+   * `mode`. Used by the debounced composer-config path: a late flush
+   * after the user has already switched modes becomes a silent no-op
+   * (zero-row UPDATE) instead of yanking the panel back to the old
+   * mode, which is exactly what `setMode` from a stale closure did.
+   */
+  setModeConfig: {
+    call: async (
+      panelId: string,
+      mode: PanelMode,
+      modeConfig: Record<string, unknown>,
+    ) => {
+      const last_updated = new Date().toISOString();
+      rememberModeConfig(panelId, mode, modeConfig, Date.parse(last_updated));
       await supabase
         .from("panels")
         .update({
-          mode,
-          mode_config: modeConfig as Database["public"]["Tables"]["panels"]["Update"]["mode_config"],
-          last_updated: new Date().toISOString(),
+          mode_config:
+            modeConfig as Database["public"]["Tables"]["panels"]["Update"]["mode_config"],
+          last_updated,
         })
         .eq("id", panelId)
+        .eq("mode", mode)
         .throwOnError();
+      // Patch the cache only after the guarded write succeeds — we
+      // can't know client-side whether the mode guard matched. An
+      // unpopulated cache is left alone (don't fabricate a fleet).
+      void globalMutate(
+        "/panels",
+        (cur?: PanelRow[]) =>
+          cur
+            ? cur.map((p) =>
+                p.id === panelId && p.mode === mode
+                  ? {
+                      ...p,
+                      mode_config:
+                        modeConfig as Database["public"]["Tables"]["panels"]["Row"]["mode_config"],
+                      last_updated,
+                    }
+                  : p,
+              )
+            : cur,
+        { revalidate: false },
+      );
     },
   },
 
   setPaused: {
     call: async (panelId: string, isPaused: boolean) => {
-      await supabase
-        .from("panels")
-        .update({
-          is_paused: isPaused,
-          last_updated: new Date().toISOString(),
-        })
-        .eq("id", panelId)
-        .throwOnError();
+      const last_updated = new Date().toISOString();
+      await patchPanelOptimistic(
+        panelId,
+        { is_paused: isPaused, last_updated },
+        async () => {
+          await supabase
+            .from("panels")
+            .update({ is_paused: isPaused, last_updated })
+            .eq("id", panelId)
+            .throwOnError();
+        },
+      );
     },
   },
 
   setOff: {
     call: async (panelId: string, isOff: boolean) => {
-      await supabase
-        .from("panels")
-        .update({
-          is_off: isOff,
-          last_updated: new Date().toISOString(),
-        })
-        .eq("id", panelId)
-        .throwOnError();
+      const last_updated = new Date().toISOString();
+      await patchPanelOptimistic(
+        panelId,
+        { is_off: isOff, last_updated },
+        async () => {
+          await supabase
+            .from("panels")
+            .update({ is_off: isOff, last_updated })
+            .eq("id", panelId)
+            .throwOnError();
+        },
+      );
     },
   },
 
   setBrightness: {
     call: async (panelId: string, brightness: number) => {
-      await supabase
-        .from("panels")
-        .update({
-          brightness: Math.max(0, Math.min(1, brightness)),
-          last_updated: new Date().toISOString(),
-        })
-        .eq("id", panelId)
-        .throwOnError();
+      const clamped = Math.max(0, Math.min(1, brightness));
+      const last_updated = new Date().toISOString();
+      await patchPanelOptimistic(
+        panelId,
+        { brightness: clamped, last_updated },
+        async () => {
+          await supabase
+            .from("panels")
+            .update({ brightness: clamped, last_updated })
+            .eq("id", panelId)
+            .throwOnError();
+        },
+      );
     },
   },
 };
@@ -264,11 +413,16 @@ export const entries = {
   add: {
     call: async (panelId: string, entry: TextEntry) => {
       const key = entriesKey(panelId);
+      // Client-generated id: the optimistic row carries the REAL id the
+      // insert will persist, so a drag-reorder that settles while the
+      // add is still in flight sends valid uuids (a fake placeholder id
+      // used to fail the whole reorder against the uuid PK).
+      const id = crypto.randomUUID();
       // The driver renders entries in ascending `order`; lowest order
       // shows at the top. min(existing)-1 is atomic (no row shifting)
       // and self-heals when a reorder rewrites everyone to 0..N-1.
       const optimisticRow: TextEntryItem = {
-        id: `optimistic-${Date.now()}`,
+        id,
         panel_id: panelId,
         created_at: new Date().toISOString(),
         order: Number.NEGATIVE_INFINITY,
@@ -284,7 +438,7 @@ export const entries = {
           await Promise.all([
             supabase
               .from("entries")
-              .insert({ panel_id: panelId, data: entry, order: minOrder - 1 })
+              .insert({ id, panel_id: panelId, data: entry, order: minOrder - 1 })
               .throwOnError(),
             updatePanelLastUpdated(panelId),
           ]);

--- a/dash/src/utils/format.ts
+++ b/dash/src/utils/format.ts
@@ -1,0 +1,4 @@
+/** Zero-pad an integer for the fixed-width instrument readouts. */
+export function pad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}

--- a/dash/src/utils/modeConfigCache.ts
+++ b/dash/src/utils/modeConfigCache.ts
@@ -1,0 +1,50 @@
+import type { PanelMode } from "@/utils/actions";
+
+/**
+ * Session-scoped cache of the last mode_config we KNOW for each
+ * `panelId:mode`. The DB stores a single mode_config column shared
+ * across modes, so switching modes overwrites the outgoing editor's
+ * work — this cache is what lets ModeSwitcher restore it on the way
+ * back.
+ *
+ * Two writers keep it fresh:
+ *  - write-through from actions.ts (setMode / setModeConfig), so the
+ *    cache always holds the last value actually written — the SWR
+ *    snapshot lags by debounce + write RTT + realtime-echo RTT, and
+ *    restoring from it silently reverted recent edits;
+ *  - ModeSwitcher's snapshot of the server row on switch.
+ * Entries carry a timestamp and the newer value wins, so a fresh
+ * local write beats the lagging SWR snapshot while an external
+ * writer's newer row beats a stale session entry.
+ */
+type Entry = { config: Record<string, unknown>; at: number };
+
+const cache = new Map<string, Entry>();
+
+const key = (panelId: string, mode: PanelMode) => `${panelId}:${mode}`;
+
+/**
+ * `at` is the wall-clock time the config is known-true for (write
+ * time, or the row's last_updated for server snapshots). It lets
+ * ModeSwitcher prefer a NEWER server row over a stale session entry —
+ * without it, an external writer's config (MCP paint, a second tab)
+ * would be silently overwritten on the next mode round-trip.
+ */
+export function rememberModeConfig(
+  panelId: string,
+  mode: PanelMode,
+  config: Record<string, unknown>,
+  at: number = Date.now(),
+): void {
+  if (Object.keys(config).length === 0) return;
+  const existing = cache.get(key(panelId, mode));
+  if (existing && existing.at > at) return;
+  cache.set(key(panelId, mode), { config, at });
+}
+
+export function recallModeConfig(
+  panelId: string,
+  mode: PanelMode,
+): Record<string, unknown> | undefined {
+  return cache.get(key(panelId, mode))?.config;
+}

--- a/dash/src/utils/useComposerConfig.ts
+++ b/dash/src/utils/useComposerConfig.ts
@@ -28,7 +28,7 @@ export function useComposerConfig<C>(
   delayMs = 250,
 ): [C, (next: C) => void, () => void] {
   const [draft, setDraft] = useSyncedFromProp<C>(`${panelId}:${mode}`, initial);
-  const [push, flush] = useDebouncedSetMode<C>(panelId, mode, delayMs);
+  const { push, flush } = useDebouncedSetMode<C>(panelId, mode, delayMs);
 
   const update = (next: C) => {
     setDraft(next);

--- a/dash/src/utils/useDebouncedSetMode.ts
+++ b/dash/src/utils/useDebouncedSetMode.ts
@@ -4,27 +4,58 @@ import { useEffect, useRef } from "react";
 
 import { panels, type PanelMode } from "@/utils/actions";
 
+export type DebouncedConfigWriter<C> = {
+  /** Stage a config and (re)arm the debounce timer. */
+  push: (config: C) => void;
+  /** Persist any staged config immediately. */
+  flush: () => void;
+  /** Drop any staged config without writing it. */
+  cancel: () => void;
+  /**
+   * Resolves once the most recently fired write settles. Await this
+   * before issuing a competing write (e.g. a file upload's setMode)
+   * so a debounced write that already left can't land after it and
+   * clobber the newer payload.
+   */
+  settle: () => Promise<void>;
+};
+
 /**
- * Coalesces rapid `setMode` calls so slider drags don't ship one
- * Supabase write per intermediate value. Auto-flushes on unmount;
- * `flush()` is exposed for commit-style events that shouldn't queue.
+ * Coalesces rapid config edits so slider drags don't ship one
+ * Supabase write per intermediate value. Auto-flushes on unmount.
+ *
+ * Writes go through `panels.setModeConfig`, which updates ONLY
+ * mode_config and is server-side guarded on the panel still being in
+ * `mode` — so a flush that fires after the user switched modes (timer
+ * or unmount; the composer unmounts precisely BECAUSE the mode
+ * changed) is a harmless zero-row no-op instead of flipping the panel
+ * back to the old mode.
  */
 export function useDebouncedSetMode<C>(
   panelId: string,
   mode: PanelMode,
   delayMs = 250,
-): [(config: C) => void, () => void] {
+): DebouncedConfigWriter<C> {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The pending config carries the panel/mode it was edited against,
   // captured at push() time (an event handler, so reading the current
   // values is fine). flush() then writes to THAT target — switching
   // panels mid-debounce (or before the unmount flush) can't misdirect
-  // a queued write to the wrong panel, the old first-render-capture bug.
+  // a queued write to the wrong panel.
   const pendingRef = useRef<{
     config: C;
     panelId: string;
     mode: PanelMode;
   } | null>(null);
+  const inFlightRef = useRef<Promise<void>>(Promise.resolve());
+
+  const cancel = () => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingRef.current = null;
+  };
 
   const flush = () => {
     if (timerRef.current != null) {
@@ -34,17 +65,34 @@ export function useDebouncedSetMode<C>(
     const pending = pendingRef.current;
     if (pending == null) return;
     pendingRef.current = null;
-    void panels.setMode.call(
-      pending.panelId,
-      pending.mode,
-      pending.config as unknown as Record<string, unknown>,
-    );
+    // Chain on the previous write rather than replacing it: writes
+    // land at the DB in issue order (no old-payload-lands-last race),
+    // and settle() — which returns this ref — genuinely waits for
+    // every outstanding write, not just the newest one.
+    inFlightRef.current = inFlightRef.current
+      .then(() =>
+        panels.setModeConfig.call(
+          pending.panelId,
+          pending.mode,
+          pending.config as unknown as Record<string, unknown>,
+        ),
+      )
+      .catch((err) => {
+        // The local draft keeps the user's edit; surface the divergence
+        // for diagnostics rather than failing silently forever.
+        console.error("debounced mode_config write failed", err);
+      });
   };
 
   const push = (config: C) => {
     pendingRef.current = { config, panelId, mode };
     if (timerRef.current != null) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(flush, delayMs);
+  };
+
+  const settle = () => {
+    flush();
+    return inFlightRef.current;
   };
 
   // Auto-flush on unmount. flush() reads the captured target from the
@@ -55,5 +103,5 @@ export function useDebouncedSetMode<C>(
     };
   }, []);
 
-  return [push, flush];
+  return { push, flush, cancel, settle };
 }

--- a/dash/src/utils/useReducedMotion.ts
+++ b/dash/src/utils/useReducedMotion.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+const subscribe = (onChange: () => void) => {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onChange);
+  return () => mql.removeEventListener("change", onChange);
+};
+
+/**
+ * True when the user asked for reduced motion. globals.css already
+ * neutralizes the CSS animations; this is for the JS-driven motion the
+ * stylesheet can't reach — the WASM simulator's rAF loop and the Life
+ * lattice ticker, which are exactly the kind of sustained full-panel
+ * movement the preference exists for.
+ */
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(QUERY).matches,
+    // SSR: assume no preference; the client snapshot corrects on mount.
+    () => false,
+  );
+}

--- a/dash/wasm-sim/Cargo.lock
+++ b/dash/wasm-sim/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "display-core"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "embedded-graphics",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sim"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "console_error_panic_hook",
  "display-core",

--- a/dash/wasm-sim/Cargo.toml
+++ b/dash/wasm-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sim"
-version = "1.1.12"
+version = "1.1.13"
 edition = "2021"
 
 # Standalone workspace. wasm-sim is `exclude`d from the parent


### PR DESCRIPTION
## Summary
A comprehensive polish pass over the dash frontend, driven by a multi-agent review (every bug claim adversarially verified against the code before fixing) plus a regression-hunt pass over the result.

### Verified bug fixes (19)
- **Life preview frozen forever** — scene-push dedupe couldn't see cell changes; now reference-tracked + memoized, and tick rate is time-based (was 2×+ fast on 120Hz displays)
- **GIFs played 10× too slow** — double ms conversion on gifuct delays (stored GIFs need re-upload to pick up correct timing)
- **Mode-switch revert race** — pending debounced config writes re-wrote the old mode; now a server-side-guarded `setModeConfig` (`.eq("mode", …)`) with ordered, chained writes
- **Paint state bled across panels** — composers now remount per `panelId:mode`
- **Dead-feeling transports** — pause/off/mode/brightness writes are optimistic with rollback, serialized against SWR's overlapping-mutation clobber
- Cross-client entry deletes now invalidate the queue (realtime DELETE payloads carry no `panel_id` under RLS)
- One malformed `mode_config` row can no longer crash-loop the dashboard
- StatusBar state precedence, marquee auto-force desync, brightness remote resync, GIF speed fader snap-back, paint right-click stroke wedge, optimistic-id reorder failures, and more

### Component library
New shared primitives (`ui.tsx`: MicroLabel / PixelValue / Lamp / Alert / EmptyState / FOCUS_RING, plus SectionPlate, ControlRow, CheckRow, UploadRow, AccentButton, useRovingRadio) replacing 3–19 drifted copies each.

### UX / mobile / a11y
Brightness on mobile, panel switcher above the fold as chip strip, 2×4 mode tiles on phones, drag-handle-only queue rows with keyboard reorder, Escape/auto-disarm on delete confirm with focus restore, touch-target minimums, native color picker, reduced-motion honored by the WASM/Life loops, live-region announcements, contrast fixes. Creative touches: ACK stamp on confirmed transmit, on-air VU bargraph, "scanning fleet" boot state.

Version lockstep bumped to **1.1.13**.

## Test plan
- `tsc --noEmit`, `eslint`, `next build` all clean
- Multi-agent adversarial verification of all bug fixes + a 4-lens regression review of the final diff (12 findings, all addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)